### PR TITLE
Fix prime_divisions bug

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "2.0.1"
+  TOOLS_VERSION = "2.0.2"
 end

--- a/lib/tonal/extensions.rb
+++ b/lib/tonal/extensions.rb
@@ -149,7 +149,7 @@ class Numeric
   # @example
   #   (31/30r).prime_divisions => [[[31, 1]], [[2, 1], [3, 1], [5, 1]]]
   #
-  def prime_divisions = self.ratio.prime_divisions
+  def prime_divisions = [self.numerator.prime_division, self.denominator.prime_division]
 
   # @return [Integer] the maximum prime factor of self
   # @example
@@ -163,6 +163,13 @@ class Numeric
   #
   def min_prime = prime_divisions.flatten(1).map(&:first).min
 
+  # @return [Vector], self expressed as a Vector
+  # @example
+  #   (3/2r).to_vector => Vector[3, 2]
+  #
+  def to_vector = Vector[self.numerator, self.denominator]
+  alias :vector :to_vector
+
   # @return [Tonal::ReducedRatio], the Ernst Levy negative of self
   # @example
   #  (7/4r).negative => (12/7)
@@ -174,33 +181,6 @@ class Numeric
   #   (3/2r).mirror => (4/3)
   #
   def mirror(axis=1/1r) = self.ratio.mirror(axis)
-end
-
-class Rational
-  # @return [Vector], self expressed as a Vector
-  # @example
-  #   (3/2r).to_vector => Vector[3, 2]
-  #
-  def to_vector = Vector[self.numerator, self.denominator]
-  alias :vector :to_vector
-
-  # @return [Array], self decomposed into its prime factors
-  # @example
-  #   (31/30r).prime_divisions => [[[31, 1]], [[2, 1], [3, 1], [5, 1]]]
-  #
-  def prime_divisions = self.ratio.prime_divisions
-
-  # @return [Integer] the maximum prime factor of self
-  # @example
-  #   (31/30r).max_prime => 31
-  #
-  def max_prime = self.ratio.max_prime
-
-  # @return [Integer] the minimum prime factor of self
-  # @example
-  #   (31/30r).min_prime => 2
-  #
-  def min_prime = self.ratio.min_prime
 end
 
 class Integer

--- a/spec/tonal_tools/extensions_spec.rb
+++ b/spec/tonal_tools/extensions_spec.rb
@@ -94,6 +94,10 @@ RSpec.describe "Extensions" do
       it "returns the prime divisions of the number" do
         expect((31/30r).prime_divisions).to eq [[[31, 1]], [[2, 1], [3, 1], [5, 1]]]
       end
+
+      context "with unreduced ratios" do
+        it("returns the prime divisions of the unreduced ratio") { expect((36/13r).prime_divisions).to eq [[[2, 2], [3, 2]], [[13, 1]]] }
+      end
     end
 
     describe "#max_prime" do


### PR DESCRIPTION
The prime_divisions extension was octave reducing the ratio before calculating its prime divisions. This was returning incorrect results for unreduced ratios, like 36/13.

This change eliminates the reduction of ratios before calculating prime divisions.

The change also consolidates extension methods that were defined twice, once in the Rational block and again in the Numeric block. All the Rational methods have been removed in favor of the Numeric entries.