### PR TITLE
Disambiguate to cents

### DIFF
--- a/docs/Array.html
+++ b/docs/Array.html
@@ -6,7 +6,7 @@
 <title>
   Class: Array
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -1463,9 +1463,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Integer.html
+++ b/docs/Integer.html
@@ -6,7 +6,7 @@
 <title>
   Class: Integer
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -808,9 +808,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Math.html
+++ b/docs/Math.html
@@ -6,7 +6,7 @@
 <title>
   Module: Math
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -230,9 +230,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Numeric.html
+++ b/docs/Numeric.html
@@ -6,7 +6,7 @@
 <title>
   Class: Numeric
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -241,7 +241,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#interval_with-instance_method" title="#interval_with (instance method)">#<strong>interval_with</strong>(ratio)  &#x21d2; Interval </a>
+      <a href="#interval_with-instance_method" title="#interval_with (instance method)">#<strong>interval_with</strong>(ratio)  &#x21d2; Tonal::Interval </a>
     
 
     
@@ -559,7 +559,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#step-instance_method" title="#step (instance method)">#<strong>step</strong>(modulo = 12)  &#x21d2; Step </a>
+      <a href="#step-instance_method" title="#step (instance method)">#<strong>step</strong>(modulo = 12)  &#x21d2; Tonal::Step </a>
     
 
     
@@ -1111,7 +1111,7 @@
       <div class="method_details ">
   <h3 class="signature " id="interval_with-instance_method">
   
-    #<strong>interval_with</strong>(ratio)  &#x21d2; <tt>Interval</tt> 
+    #<strong>interval_with</strong>(ratio)  &#x21d2; <tt><span class='object_link'><a href="Tonal/Interval.html" title="Tonal::Interval (class)">Tonal::Interval</a></span></tt> 
   
 
   
@@ -1156,7 +1156,7 @@
     <li>
       
       
-        <span class='type'>(<tt>Interval</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="Tonal/Interval.html" title="Tonal::Interval (class)">Tonal::Interval</a></span></tt>)</span>
       
       
       
@@ -2022,7 +2022,7 @@
       <div class="method_details ">
   <h3 class="signature " id="step-instance_method">
   
-    #<strong>step</strong>(modulo = 12)  &#x21d2; <tt>Step</tt> 
+    #<strong>step</strong>(modulo = 12)  &#x21d2; <tt><span class='object_link'><a href="Tonal/Step.html" title="Tonal::Step (class)">Tonal::Step</a></span></tt> 
   
 
   
@@ -2069,7 +2069,7 @@
     <li>
       
       
-        <span class='type'>(<tt>Step</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="Tonal/Step.html" title="Tonal::Step (class)">Tonal::Step</a></span></tt>)</span>
       
       
       
@@ -2561,9 +2561,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Prime.html
+++ b/docs/Prime.html
@@ -6,7 +6,7 @@
 <title>
   Class: Prime
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -253,9 +253,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal.html
+++ b/docs/Tonal.html
@@ -6,7 +6,7 @@
 <title>
   Module: Tonal
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -112,7 +112,7 @@
         <dt id="TOOLS_VERSION-constant" class="">TOOLS_VERSION =
           
         </dt>
-        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>2.0.2</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>3.0.1</span><span class='tstring_end'>&quot;</span></span></pre></dd>
       
     </dl>
   
@@ -128,9 +128,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Cents.html
+++ b/docs/Tonal/Cents.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Cents
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -226,7 +226,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#default_tolerance-class_method" title="default_tolerance (class method)">.<strong>default_tolerance</strong>  &#x21d2; Cents </a>
+      <a href="#default_tolerance-class_method" title="default_tolerance (class method)">.<strong>default_tolerance</strong>  &#x21d2; Tonal::Cents </a>
     
 
     
@@ -283,7 +283,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(cents: nil, log: nil, ratio: nil, precision: PRECISION)  &#x21d2; Cents </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(cents: nil, log: nil, ratio: nil, precision: PRECISION)  &#x21d2; Tonal::Cents </a>
     
 
     
@@ -323,7 +323,7 @@
   
     <span class="summary_desc"><div class='inline'><dl class="rdoc-list label-list"><dt>String
 <dd>
-<p>the string representation of Cents.</p>
+<p>the string representation of Tonal::Cents.</p>
 </dd></dl>
 </div></span>
   
@@ -347,7 +347,7 @@
   
 
   
-    <span class="summary_desc"><div class='inline'><dl class="rdoc-list label-list"><dt>Cents
+    <span class="summary_desc"><div class='inline'><dl class="rdoc-list label-list"><dt>Tonal::Cents
 <dd>
 <p>nearest hundredth cent value.</p>
 </dd></dl>
@@ -443,7 +443,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(cents: nil, log: nil, ratio: nil, precision: PRECISION)  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Cents (class)">Cents</a></span></tt> 
+    #<strong>initialize</strong>(cents: nil, log: nil, ratio: nil, precision: PRECISION)  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt> 
   
 
   
@@ -758,7 +758,7 @@
       <div class="method_details first">
   <h3 class="signature first" id="default_tolerance-class_method">
   
-    .<strong>default_tolerance</strong>  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Cents (class)">Cents</a></span></tt> 
+    .<strong>default_tolerance</strong>  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt> 
   
 
   
@@ -788,7 +788,7 @@
     <li>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="" title="Tonal::Cents (class)">Cents</a></span></tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt>)</span>
       
       
       
@@ -881,7 +881,7 @@
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns [String] the string representation of Cents.</p>
+<p>Returns [String] the string representation of Tonal::Cents.</p>
 
 
   </div>
@@ -909,7 +909,7 @@
         
         <div class='inline'><dl class="rdoc-list label-list"><dt>String
 <dd>
-<p>the string representation of Cents</p>
+<p>the string representation of Tonal::Cents</p>
 </dd></dl>
 </div>
       
@@ -950,7 +950,7 @@
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns [Cents] nearest hundredth cent value.</p>
+<p>Returns [Tonal::Cents] nearest hundredth cent value.</p>
 
 
   </div>
@@ -976,7 +976,7 @@
       
       
         
-        <div class='inline'><dl class="rdoc-list label-list"><dt>Cents
+        <div class='inline'><dl class="rdoc-list label-list"><dt>Tonal::Cents
 <dd>
 <p>nearest hundredth cent value</p>
 </dd></dl>
@@ -1220,9 +1220,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Comma.html
+++ b/docs/Tonal/Comma.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Comma
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -504,9 +504,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Hertz.html
+++ b/docs/Tonal/Hertz.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Hertz
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -156,7 +156,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#a440-class_method" title="a440 (class method)">.<strong>a440</strong>  &#x21d2; Hertz </a>
+      <a href="#a440-class_method" title="a440 (class method)">.<strong>a440</strong>  &#x21d2; Tonal::Hertz </a>
     
 
     
@@ -211,7 +211,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(arg)  &#x21d2; Hertz </a>
+      <a href="#initialize-instance_method" title="#initialize (instance method)">#<strong>initialize</strong>(arg)  &#x21d2; Tonal::Hertz </a>
     
 
     
@@ -250,7 +250,7 @@
 
   
     <span class="summary_desc"><div class='inline'>
-<p>The string representation of Hertz.</p>
+<p>The string representation of Tonal::Hertz.</p>
 </div></span>
   
 </li>
@@ -336,7 +336,7 @@
     <div class="method_details first">
   <h3 class="signature first" id="initialize-instance_method">
   
-    #<strong>initialize</strong>(arg)  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Hertz (class)">Hertz</a></span></tt> 
+    #<strong>initialize</strong>(arg)  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Hertz (class)">Tonal::Hertz</a></span></tt> 
   
 
   
@@ -354,7 +354,7 @@
     <p class="tag_title">Examples:</p>
     
       
-      <pre class="example code"><code><span class='const'><span class='object_link'><a href="" title="Tonal::Hertz (class)">Hertz</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='float'>1000.0</span><span class='rparen'>)</span> <span class='op'>=&gt;</span> <span class='float'>1000.0</span></code></pre>
+      <pre class="example code"><code><span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="" title="Tonal::Hertz (class)">Hertz</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='float'>1000.0</span><span class='rparen'>)</span> <span class='op'>=&gt;</span> <span class='float'>1000.0</span></code></pre>
     
   </div>
 <p class="tag_title">Parameters:</p>
@@ -516,7 +516,7 @@
       <div class="method_details first">
   <h3 class="signature first" id="a440-class_method">
   
-    .<strong>a440</strong>  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Hertz (class)">Hertz</a></span></tt> 
+    .<strong>a440</strong>  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Hertz (class)">Tonal::Hertz</a></span></tt> 
   
 
   
@@ -546,7 +546,7 @@
     <li>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="" title="Tonal::Hertz (class)">Hertz</a></span></tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="" title="Tonal::Hertz (class)">Tonal::Hertz</a></span></tt>)</span>
       
       
       
@@ -628,7 +628,7 @@
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns the string representation of Hertz.</p>
+<p>Returns the string representation of Tonal::Hertz.</p>
 
 
   </div>
@@ -639,7 +639,7 @@
     <p class="tag_title">Examples:</p>
     
       
-      <pre class="example code"><code><span class='const'><span class='object_link'><a href="" title="Tonal::Hertz (class)">Hertz</a></span></span><span class='lparen'>(</span><span class='float'>1000.0</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_inspect'>inspect</span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>1000.0</span><span class='tstring_end'>&quot;</span></span></code></pre>
+      <pre class="example code"><code><span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="" title="Tonal::Hertz (class)">Hertz</a></span></span><span class='lparen'>(</span><span class='float'>1000.0</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_inspect'>inspect</span> <span class='op'>=&gt;</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>1000.0</span><span class='tstring_end'>&quot;</span></span></code></pre>
     
   </div>
 
@@ -655,7 +655,7 @@
       
         &mdash;
         <div class='inline'>
-<p>the string representation of Hertz</p>
+<p>the string representation of Tonal::Hertz</p>
 </div>
       
     </li>
@@ -822,9 +822,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Interval.html
+++ b/docs/Tonal/Interval.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Interval
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -687,9 +687,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Log.html
+++ b/docs/Tonal/Log.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Log
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -324,7 +324,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#step-instance_method" title="#step (instance method)">#<strong>step</strong>(modulo)  &#x21d2; Step </a>
+      <a href="#step-instance_method" title="#step (instance method)">#<strong>step</strong>(modulo)  &#x21d2; Tonal::Step </a>
     
 
     
@@ -873,7 +873,7 @@
       <div class="method_details ">
   <h3 class="signature " id="step-instance_method">
   
-    #<strong>step</strong>(modulo)  &#x21d2; <tt><span class='object_link'><a href="Step.html" title="Tonal::Step (class)">Step</a></span></tt> 
+    #<strong>step</strong>(modulo)  &#x21d2; <tt><span class='object_link'><a href="Step.html" title="Tonal::Step (class)">Tonal::Step</a></span></tt> 
   
 
   
@@ -903,7 +903,7 @@
     <li>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="Step.html" title="Tonal::Step (class)">Step</a></span></tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="Step.html" title="Tonal::Step (class)">Tonal::Step</a></span></tt>)</span>
       
       
       
@@ -1016,9 +1016,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Log2.html
+++ b/docs/Tonal/Log2.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Log2
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -216,9 +216,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Ratio.html
+++ b/docs/Tonal/Ratio.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Ratio
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -608,7 +608,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#cent_diff-instance_method" title="#cent_diff (instance method)">#<strong>cent_diff</strong>(other_ratio)  &#x21d2; Cents </a>
+      <a href="#cent_diff-instance_method" title="#cent_diff (instance method)">#<strong>cent_diff</strong>(other_ratio)  &#x21d2; Tonal::Cents </a>
     
 
     
@@ -708,7 +708,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#efficiency-instance_method" title="#efficiency (instance method)">#<strong>efficiency</strong>(modulo)  &#x21d2; Float </a>
+      <a href="#efficiency-instance_method" title="#efficiency (instance method)">#<strong>efficiency</strong>(modulo)  &#x21d2; Tonal::Cents </a>
     
 
     
@@ -884,7 +884,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#invert!-instance_method" title="#invert! (instance method)">#<strong>invert!</strong>  &#x21d2; self </a>
+      <a href="#invert!-instance_method" title="#invert! (instance method)">#<strong>invert!</strong>  &#x21d2; Tonal::Ratio </a>
     
 
     
@@ -1078,7 +1078,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#negative-instance_method" title="#negative (instance method)">#<strong>negative</strong>  &#x21d2; Object </a>
+      <a href="#negative-instance_method" title="#negative (instance method)">#<strong>negative</strong>  &#x21d2; Tonal::ReducedRatio </a>
     
 
     
@@ -1093,7 +1093,7 @@
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Tonal::ReducedRatio the Ernst Levy negative of self.</p>
+<p>The Ernst Levy negative of self.</p>
 </div></span>
   
 </li>
@@ -1773,18 +1773,7 @@
 17
 18
 19
-20
-21
-22
-23
-24
-25
-26
-27
-28
-29
-30
-31</pre>
+20</pre>
     </td>
     <td>
       <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 15</span>
@@ -1793,18 +1782,7 @@
   <span class='id identifier rubyid_raise'>raise</span> <span class='const'>ArgumentError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Antecedent must be Numeric</span><span class='tstring_end'>&quot;</span></span> <span class='kw'>unless</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_kind_of?'>kind_of?</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Numeric.html" title="Numeric (class)">Numeric</a></span></span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise'>raise</span> <span class='const'>ArgumentError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Consequent must be Numeric or nil</span><span class='tstring_end'>&quot;</span></span> <span class='kw'>unless</span> <span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='period'>.</span><span class='id identifier rubyid_kind_of?'>kind_of?</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Numeric.html" title="Numeric (class)">Numeric</a></span></span><span class='rparen'>)</span> <span class='op'>||</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span><span class='rparen'>)</span>
 
-  <span class='kw'>if</span> <span class='id identifier rubyid_consequent'>consequent</span>
-    <span class='ivar'>@antecedent</span> <span class='op'>=</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_abs'>abs</span>
-    <span class='ivar'>@consequent</span> <span class='op'>=</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='period'>.</span><span class='id identifier rubyid_abs'>abs</span>
-  <span class='kw'>else</span>
-    <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>=</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_abs'>abs</span>
-    <span class='ivar'>@antecedent</span> <span class='op'>=</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_numerator'>numerator</span>
-    <span class='ivar'>@consequent</span> <span class='op'>=</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span>
-  <span class='kw'>end</span>
-  <span class='ivar'>@equave</span> <span class='op'>=</span> <span class='id identifier rubyid_equave'>equave</span>
-  <span class='ivar'>@reduced_antecedent</span><span class='comma'>,</span> <span class='ivar'>@reduced_consequent</span> <span class='op'>=</span> <span class='id identifier rubyid__equave_reduce'>_equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
-  <span class='ivar'>@label</span> <span class='op'>=</span> <span class='id identifier rubyid_label'>label</span>
-  <span class='ivar'>@approximation</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Ratio/Approximation.html" title="Tonal::Ratio::Approximation (class)">Approximation</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Ratio/Approximation.html#initialize-instance_method" title="Tonal::Ratio::Approximation#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='kw'>self</span><span class='rparen'>)</span>
+  <span class='id identifier rubyid__initialize'>_initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='label'>label:</span><span class='comma'>,</span> <span class='label'>equave:</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -2138,12 +2116,12 @@
       <pre class="lines">
 
 
-89
-90
-91</pre>
+78
+79
+80</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 89</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 78</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_ed'>ed</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='comma'>,</span> <span class='id identifier rubyid_step'>step</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='int'>2</span><span class='op'>**</span><span class='lparen'>(</span><span class='id identifier rubyid_step'>step</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span><span class='op'>/</span><span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -2235,19 +2213,19 @@
       <pre class="lines">
 
 
-70
-71
-72
-73
-74
-75
-76
-77
-78
-79</pre>
+59
+60
+61
+62
+63
+64
+65
+66
+67
+68</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 70</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 59</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_random_ratio'>random_ratio</span><span class='lparen'>(</span><span class='id identifier rubyid_number_of_factors'>number_of_factors</span> <span class='op'>=</span> <span class='int'>2</span><span class='comma'>,</span> <span class='label'>within:</span> <span class='int'>100</span><span class='comma'>,</span> <span class='label'>reduced:</span> <span class='kw'>false</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_primes'>primes</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="../Prime.html" title="Prime (class)">Prime</a></span></span><span class='period'>.</span><span class='id identifier rubyid_each'>each</span><span class='lparen'>(</span><span class='id identifier rubyid_within'>within</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_a'>to_a</span>
@@ -2372,12 +2350,12 @@
       <pre class="lines">
 
 
-43
-44
-45</pre>
+32
+33
+34</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 43</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 32</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_superparticular'>superparticular</span><span class='lparen'>(</span><span class='id identifier rubyid_n'>n</span><span class='comma'>,</span> <span class='label'>factor:</span> <span class='int'>1</span><span class='op'>/</span><span class='rational'>1r</span><span class='comma'>,</span> <span class='label'>superpart:</span> <span class='symbol'>:upper</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_superpartient'>superpartient</span><span class='lparen'>(</span><span class='id identifier rubyid_n'>n</span><span class='comma'>,</span> <span class='label'>summand:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>factor:</span><span class='comma'>,</span> <span class='label'>superpart:</span><span class='rparen'>)</span>
@@ -2511,17 +2489,17 @@
       <pre class="lines">
 
 
-55
-56
-57
-58
-59
-60
-61
-62</pre>
+44
+45
+46
+47
+48
+49
+50
+51</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 55</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 44</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_superpartient'>superpartient</span><span class='lparen'>(</span><span class='id identifier rubyid_n'>n</span><span class='comma'>,</span> <span class='label'>summand:</span><span class='comma'>,</span> <span class='label'>factor:</span> <span class='int'>1</span><span class='op'>/</span><span class='rational'>1r</span><span class='comma'>,</span> <span class='label'>superpart:</span> <span class='symbol'>:upper</span><span class='rparen'>)</span>
   <span class='kw'>case</span> <span class='id identifier rubyid_superpart'>superpart</span><span class='period'>.</span><span class='id identifier rubyid_to_sym'>to_sym</span><span class='period'>.</span><span class='id identifier rubyid_downcase'>downcase</span>
@@ -2625,12 +2603,12 @@
       <pre class="lines">
 
 
-100
-101
-102</pre>
+89
+90
+91</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 100</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 89</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_within_cents?'>within_cents?</span><span class='lparen'>(</span><span class='id identifier rubyid_cents1'>cents1</span><span class='comma'>,</span> <span class='id identifier rubyid_cents2'>cents2</span><span class='comma'>,</span> <span class='id identifier rubyid_within'>within</span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='id identifier rubyid_cents1'>cents1</span> <span class='op'>-</span> <span class='id identifier rubyid_cents2'>cents2</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_abs'>abs</span> <span class='op'>&lt;=</span> <span class='id identifier rubyid_within'>within</span>
@@ -2661,12 +2639,12 @@
       <pre class="lines">
 
 
-496
-497
-498</pre>
+486
+487
+488</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 496</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 486</span>
 
 <span class='kw'>def</span> <span class='op'>*</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>*</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span> <span class='op'>*</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_consequent'>consequent</span><span class='rparen'>)</span>
@@ -2691,12 +2669,12 @@
       <pre class="lines">
 
 
-504
-505
-506</pre>
+494
+495
+496</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 504</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 494</span>
 
 <span class='kw'>def</span> <span class='op'>**</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:**</span><span class='rparen'>)</span>
@@ -2721,12 +2699,12 @@
       <pre class="lines">
 
 
-488
-489
-490</pre>
+478
+479
+480</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 488</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 478</span>
 
 <span class='kw'>def</span> <span class='op'>+</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:+</span><span class='rparen'>)</span>
@@ -2751,12 +2729,12 @@
       <pre class="lines">
 
 
-492
-493
-494</pre>
+482
+483
+484</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 492</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 482</span>
 
 <span class='kw'>def</span> <span class='op'>-</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:-</span><span class='rparen'>)</span>
@@ -2781,12 +2759,12 @@
       <pre class="lines">
 
 
-500
-501
-502</pre>
+490
+491
+492</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 500</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 490</span>
 
 <span class='kw'>def</span> <span class='op'>/</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>*</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span> <span class='op'>*</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span>
@@ -2811,14 +2789,14 @@
       <pre class="lines">
 
 
-550
-551
-552
-553
-554</pre>
+540
+541
+542
+543
+544</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 550</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 540</span>
 
 <span class='kw'>def</span> <span class='op'>&lt;=&gt;</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_left'>left</span> <span class='op'>=</span> <span class='id identifier rubyid_consequent'>consequent</span> <span class='op'>==</span> <span class='int'>0</span> <span class='op'>?</span> <span class='const'>Float</span><span class='op'>::</span><span class='const'>INFINITY</span> <span class='op'>:</span> <span class='const'>Rational</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rparen'>)</span>
@@ -2874,12 +2852,12 @@
       <pre class="lines">
 
 
-112
-113
-114</pre>
+101
+102
+103</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 112</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 101</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_approximate'>approximate</span>
   <span class='ivar'>@approximation</span>
@@ -2945,12 +2923,12 @@
       <pre class="lines">
 
 
-391
-392
-393</pre>
+379
+380
+381</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 391</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 379</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_benedetti_height'>benedetti_height</span>
   <span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span> <span class='op'>*</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span>
@@ -2963,7 +2941,7 @@
       <div class="method_details ">
   <h3 class="signature " id="cent_diff-instance_method">
   
-    #<strong>cent_diff</strong>(other_ratio)  &#x21d2; <tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></tt> 
+    #<strong>cent_diff</strong>(other_ratio)  &#x21d2; <tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt> 
   
 
   
@@ -3013,7 +2991,7 @@
     <li>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt>)</span>
       
       
       
@@ -3032,12 +3010,12 @@
       <pre class="lines">
 
 
-466
-467
-468</pre>
+456
+457
+458</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 466</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 456</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_cent_diff'>cent_diff</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_cents'>cents</span> <span class='op'>-</span> <span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='period'>.</span><span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_cents'>cents</span>
@@ -3103,12 +3081,12 @@
       <pre class="lines">
 
 
-545
-546
-547</pre>
+535
+536
+537</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 545</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 535</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_combination'>combination</span>
   <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>+</span> <span class='id identifier rubyid_consequent'>consequent</span>
@@ -3174,12 +3152,12 @@
       <pre class="lines">
 
 
-536
-537
-538</pre>
+526
+527
+528</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 536</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 526</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_difference'>difference</span>
   <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>-</span> <span class='id identifier rubyid_consequent'>consequent</span>
@@ -3256,13 +3234,13 @@
       <pre class="lines">
 
 
-445
-446
-447
-448</pre>
+435
+436
+437
+438</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 445</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 435</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_div_times'>div_times</span><span class='lparen'>(</span><span class='id identifier rubyid_ratio'>ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_ratio'>ratio</span> <span class='op'>=</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_ratio'>ratio</span>
@@ -3276,7 +3254,7 @@
       <div class="method_details ">
   <h3 class="signature " id="efficiency-instance_method">
   
-    #<strong>efficiency</strong>(modulo)  &#x21d2; <tt>Float</tt> 
+    #<strong>efficiency</strong>(modulo)  &#x21d2; <tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt> 
   
 
   
@@ -3321,7 +3299,7 @@
     <li>
       
       
-        <span class='type'>(<tt>Float</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt>)</span>
       
       
       
@@ -3340,15 +3318,19 @@
       <pre class="lines">
 
 
-436
-437
-438</pre>
+424
+425
+426
+427
+428</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 436</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 424</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_efficiency'>efficiency</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span>
-  <span class='lparen'>(</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html#CENT_SCALE-constant" title="Tonal::Cents::CENT_SCALE (constant)">CENT_SCALE</a></span></span> <span class='op'>*</span> <span class='id identifier rubyid_step'>step</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_step'>step</span> <span class='op'>/</span> <span class='id identifier rubyid_modulo'>modulo</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span><span class='rparen'>)</span> <span class='op'>-</span> <span class='id identifier rubyid_to_cents'>to_cents</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html#PRECISION-constant" title="Tonal::Cents::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
+  <span class='comment'># We want the efficiency from the ratio, instead of from the step.
+</span>  <span class='comment'># If step efficiency is X cents, then ratio efficiency is -X cents.
+</span>  <span class='id identifier rubyid_step'>step</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_efficiency'>efficiency</span> <span class='op'>*</span> <span class='op'>-</span><span class='float'>1.0</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -3433,12 +3415,12 @@
       <pre class="lines">
 
 
-221
-222
-223</pre>
+210
+211
+212</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 221</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 210</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_equave_reduce'>equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='op'>=</span><span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid__equave_reduce'>_equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span><span class='rparen'>)</span>
@@ -3526,13 +3508,13 @@
       <pre class="lines">
 
 
-232
-233
-234
-235</pre>
+221
+222
+223
+224</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 232</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 221</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_equave_reduce!'>equave_reduce!</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='op'>=</span><span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='ivar'>@antecedent</span><span class='comma'>,</span> <span class='ivar'>@consequent</span> <span class='op'>=</span> <span class='id identifier rubyid__equave_reduce'>_equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -3602,12 +3584,12 @@
       <pre class="lines">
 
 
-212
-213
-214</pre>
+201
+202
+203</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 212</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 201</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_fraction_reduce'>fraction_reduce</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_to_r'>to_r</span><span class='rparen'>)</span>
@@ -3673,12 +3655,12 @@
       <pre class="lines">
 
 
-483
-484
-485</pre>
+473
+474
+475</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 483</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 473</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_inspect'>inspect</span>
   <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>(</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_consequent'>consequent</span><span class='embexpr_end'>}</span><span class='tstring_content'>)</span><span class='tstring_end'>&quot;</span></span>
@@ -3744,12 +3726,12 @@
       <pre class="lines">
 
 
-252
-253
-254</pre>
+241
+242
+243</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 252</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 241</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_invert'>invert</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span>
@@ -3762,7 +3744,7 @@
       <div class="method_details ">
   <h3 class="signature " id="invert!-instance_method">
   
-    #<strong>invert!</strong>  &#x21d2; <tt>self</tt> 
+    #<strong>invert!</strong>  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Ratio (class)">Tonal::Ratio</a></span></tt> 
   
 
   
@@ -3792,7 +3774,7 @@
     <li>
       
       
-        <span class='type'>(<tt>self</tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="" title="Tonal::Ratio (class)">Tonal::Ratio</a></span></tt>)</span>
       
       
       
@@ -3811,18 +3793,16 @@
       <pre class="lines">
 
 
-261
-262
-263
-264
-265</pre>
+250
+251
+252
+253</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 261</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 250</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_invert!'>invert!</span>
-  <span class='id identifier rubyid_tmp'>tmp</span> <span class='op'>=</span> <span class='id identifier rubyid_antecedent'>antecedent</span>
-  <span class='ivar'>@antecedent</span><span class='comma'>,</span> <span class='ivar'>@consequent</span> <span class='op'>=</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_tmp'>tmp</span>
+  <span class='id identifier rubyid__initialize'>_initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='id identifier rubyid_label'>label</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
   <span class='kw'>self</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -3874,15 +3854,15 @@
       <pre class="lines">
 
 
-472
-473
-474
-475
-476
-477</pre>
+462
+463
+464
+465
+466
+467</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 472</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 462</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_label'>label</span>
   <span class='comment'># Return label, if defined; or,
@@ -3967,12 +3947,12 @@
       <pre class="lines">
 
 
-528
-529
-530</pre>
+518
+519
+520</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 528</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 518</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_lcm'>lcm</span><span class='lparen'>(</span><span class='id identifier rubyid_lhs'>lhs</span><span class='rparen'>)</span>
   <span class='lbracket'>[</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span><span class='comma'>,</span> <span class='id identifier rubyid_lhs'>lhs</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_lcm'>lcm</span>
@@ -4034,12 +4014,12 @@
       <pre class="lines">
 
 
-419
-420
-421</pre>
+407
+408
+409</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 419</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 407</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_log_weil_height'>log_weil_height</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_weil_height'>weil_height</span><span class='rparen'>)</span>
@@ -4101,12 +4081,12 @@
       <pre class="lines">
 
 
-371
-372
-373</pre>
+359
+360
+361</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 371</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 359</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_max_prime'>max_prime</span>
   <span class='id identifier rubyid_prime_divisions'>prime_divisions</span><span class='period'>.</span><span class='id identifier rubyid_flatten'>flatten</span><span class='lparen'>(</span><span class='int'>1</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:first</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_max'>max</span>
@@ -4187,12 +4167,12 @@
       <pre class="lines">
 
 
-513
-514
-515</pre>
+503
+504
+505</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 513</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 503</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mediant_sum'>mediant_sum</span><span class='lparen'>(</span><span class='id identifier rubyid_number'>number</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>+</span> <span class='id identifier rubyid_number'>number</span><span class='period'>.</span><span class='id identifier rubyid_numerator'>numerator</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span> <span class='op'>+</span> <span class='id identifier rubyid_number'>number</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span><span class='rparen'>)</span>
@@ -4254,12 +4234,12 @@
       <pre class="lines">
 
 
-379
-380
-381</pre>
+367
+368
+369</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 379</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 367</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_min_prime'>min_prime</span>
   <span class='id identifier rubyid_prime_divisions'>prime_divisions</span><span class='period'>.</span><span class='id identifier rubyid_flatten'>flatten</span><span class='lparen'>(</span><span class='int'>1</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:first</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_min'>min</span>
@@ -4338,12 +4318,12 @@
       <pre class="lines">
 
 
-272
-273
-274</pre>
+260
+261
+262</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 272</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 260</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mirror'>mirror</span><span class='lparen'>(</span><span class='id identifier rubyid_axis'>axis</span><span class='op'>=</span><span class='int'>1</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_axis'>axis</span><span class='rparen'>)</span> <span class='op'>**</span> <span class='int'>2</span><span class='rparen'>)</span> <span class='op'>/</span> <span class='kw'>self</span>
@@ -4356,7 +4336,7 @@
       <div class="method_details ">
   <h3 class="signature " id="negative-instance_method">
   
-    #<strong>negative</strong>  &#x21d2; <tt>Object</tt> 
+    #<strong>negative</strong>  &#x21d2; <tt><span class='object_link'><a href="ReducedRatio.html" title="Tonal::ReducedRatio (class)">Tonal::ReducedRatio</a></span></tt> 
   
 
   
@@ -4365,7 +4345,7 @@
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns Tonal::ReducedRatio the Ernst Levy negative of self.</p>
+<p>Returns the Ernst Levy negative of self.</p>
 
 
   </div>
@@ -4386,13 +4366,13 @@
     <li>
       
       
-        <span class='type'></span>
+        <span class='type'>(<tt><span class='object_link'><a href="ReducedRatio.html" title="Tonal::ReducedRatio (class)">Tonal::ReducedRatio</a></span></tt>)</span>
       
       
       
-        
+        &mdash;
         <div class='inline'>
-<p>Tonal::ReducedRatio the Ernst Levy negative of self</p>
+<p>the Ernst Levy negative of self</p>
 </div>
       
     </li>
@@ -4405,12 +4385,12 @@
       <pre class="lines">
 
 
-280
-281
-282</pre>
+268
+269
+270</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 280</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 268</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_negative'>negative</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='int'>3</span><span class='op'>/</span><span class='rational'>2r</span><span class='rparen'>)</span> <span class='op'>/</span> <span class='kw'>self</span>
@@ -4489,12 +4469,12 @@
       <pre class="lines">
 
 
-194
-195
-196</pre>
+183
+184
+185</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 194</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 183</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_period_degrees'>period_degrees</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='int'>2</span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='float'>360.0</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log'>log</span><span class='lparen'>(</span><span class='id identifier rubyid_to_f'>to_f</span><span class='comma'>,</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
@@ -4573,12 +4553,12 @@
       <pre class="lines">
 
 
-203
-204
-205</pre>
+192
+193
+194</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 203</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 192</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_period_radians'>period_radians</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='int'>2</span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='int'>2</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='op'>::</span><span class='const'>PI</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log'>log</span><span class='lparen'>(</span><span class='id identifier rubyid_to_f'>to_f</span><span class='comma'>,</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
@@ -4657,12 +4637,12 @@
       <pre class="lines">
 
 
-328
-329
-330</pre>
+316
+317
+318</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 328</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 316</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_planar_degrees'>planar_degrees</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='int'>2</span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_atan2'>atan2</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span> <span class='op'>*</span> <span class='int'>180</span><span class='op'>/</span><span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='op'>::</span><span class='const'>PI</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
@@ -4741,12 +4721,12 @@
       <pre class="lines">
 
 
-337
-338
-339</pre>
+325
+326
+327</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 337</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 325</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_planar_radians'>planar_radians</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='int'>2</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_atan2'>atan2</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
@@ -4827,13 +4807,13 @@
       <pre class="lines">
 
 
-455
-456
-457
-458</pre>
+445
+446
+447
+448</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 455</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 445</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_plus_minus'>plus_minus</span><span class='lparen'>(</span><span class='id identifier rubyid_ratio'>ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_ratio'>ratio</span> <span class='op'>=</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_ratio'>ratio</span>
@@ -4896,13 +4876,13 @@
       <pre class="lines">
 
 
-345
-346
-347
-348</pre>
+333
+334
+335
+336</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 345</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 333</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_prime_divisions'>prime_divisions</span>
   <span class='kw'>return</span> <span class='lbracket'>[</span><span class='lbracket'>[</span><span class='lbracket'>[</span><span class='int'>2</span><span class='comma'>,</span> <span class='int'>1</span><span class='rbracket'>]</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='lbracket'>[</span><span class='lbracket'>[</span><span class='int'>2</span><span class='comma'>,</span> <span class='int'>1</span><span class='rbracket'>]</span><span class='rbracket'>]</span><span class='rbracket'>]</span> <span class='kw'>if</span> <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>==</span> <span class='int'>1</span>
@@ -4969,20 +4949,20 @@
       <pre class="lines">
 
 
-354
-355
-356
-357
-358
-359
-360
-361
-362
-363
-364</pre>
+342
+343
+344
+345
+346
+347
+348
+349
+350
+351
+352</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 354</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 342</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_prime_vector'>prime_vector</span>
   <span class='id identifier rubyid_pds'>pds</span> <span class='op'>=</span> <span class='id identifier rubyid_prime_divisions'>prime_divisions</span>
@@ -5044,12 +5024,12 @@
       <pre class="lines">
 
 
-106
-107
-108</pre>
+95
+96
+97</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 106</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 95</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_ratio'>ratio</span>
   <span class='kw'>self</span>
@@ -5139,13 +5119,13 @@
       <pre class="lines">
 
 
-307
-308
-309
-310</pre>
+295
+296
+297
+298</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 307</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 295</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_scale'>scale</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span> <span class='id identifier rubyid_b'>b</span><span class='op'>=</span><span class='id identifier rubyid_a'>a</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise_if_negative'>raise_if_negative</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span><span class='id identifier rubyid_b'>b</span><span class='rparen'>)</span>
@@ -5236,13 +5216,13 @@
       <pre class="lines">
 
 
-318
-319
-320
-321</pre>
+306
+307
+308
+309</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 318</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 306</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_shear'>shear</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span> <span class='id identifier rubyid_b'>b</span><span class='op'>=</span><span class='id identifier rubyid_a'>a</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise_if_negative'>raise_if_negative</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span><span class='id identifier rubyid_b'>b</span><span class='rparen'>)</span>
@@ -5305,15 +5285,15 @@
       <pre class="lines">
 
 
-185
-186
-187</pre>
+174
+175
+176</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 185</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 174</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_step'>step</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='op'>=</span><span class='int'>12</span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_to_log2'>to_log2</span><span class='period'>.</span><span class='id identifier rubyid_step'>step</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span>
+  <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Step.html" title="Tonal::Step (class)">Step</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Step.html#initialize-instance_method" title="Tonal::Step#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='comma'>,</span> <span class='label'>modulo:</span> <span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -5376,12 +5356,12 @@
       <pre class="lines">
 
 
-400
-401
-402</pre>
+388
+389
+390</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 400</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 388</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_tenney_height'>tenney_height</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_benedetti_height'>benedetti_height</span><span class='rparen'>)</span>
@@ -5443,12 +5423,12 @@
       <pre class="lines">
 
 
-124
-125
-126</pre>
+113
+114
+115</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 124</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 113</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_a'>to_a</span>
   <span class='lbracket'>[</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rbracket'>]</span>
@@ -5514,12 +5494,12 @@
       <pre class="lines">
 
 
-176
-177
-178</pre>
+165
+166
+167</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 176</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 165</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_cents'>to_cents</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='rparen'>)</span>
@@ -5581,12 +5561,12 @@
       <pre class="lines">
 
 
-149
-150
-151</pre>
+138
+139
+140</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 149</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 138</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_f'>to_f</span>
   <span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span> <span class='op'>/</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span>
@@ -5669,12 +5649,12 @@
       <pre class="lines">
 
 
-158
-159
-160</pre>
+147
+148
+149</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 158</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 147</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_log'>to_log</span><span class='lparen'>(</span><span class='id identifier rubyid_base'>base</span><span class='op'>=</span><span class='int'>2</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log.html" title="Tonal::Log (class)">Log</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='comma'>,</span> <span class='label'>base:</span> <span class='id identifier rubyid_base'>base</span><span class='rparen'>)</span>
@@ -5740,12 +5720,12 @@
       <pre class="lines">
 
 
-167
-168
-169</pre>
+156
+157
+158</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 167</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 156</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_log2'>to_log2</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='rparen'>)</span>
@@ -5807,13 +5787,13 @@
       <pre class="lines">
 
 
-140
-141
-142
-143</pre>
+129
+130
+131
+132</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 140</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 129</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_r'>to_r</span>
   <span class='kw'>return</span> <span class='const'>Float</span><span class='op'>::</span><span class='const'>INFINITY</span> <span class='kw'>if</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='period'>.</span><span class='id identifier rubyid_zero?'>zero?</span> <span class='op'>||</span> <span class='op'>!</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_finite?'>finite?</span>
@@ -5880,12 +5860,12 @@
       <pre class="lines">
 
 
-243
-244
-245</pre>
+232
+233
+234</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 243</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 232</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_reduced_ratio'>to_reduced_ratio</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="ReducedRatio.html" title="Tonal::ReducedRatio (class)">ReducedRatio</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -5947,12 +5927,12 @@
       <pre class="lines">
 
 
-132
-133
-134</pre>
+121
+122
+123</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 132</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 121</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_v'>to_v</span>
   <span class='const'><span class='object_link'><a href="../Vector.html" title="Vector (class)">Vector</a></span></span><span class='lbracket'>[</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rbracket'>]</span>
@@ -6048,13 +6028,13 @@
       <pre class="lines">
 
 
-296
-297
-298
-299</pre>
+284
+285
+286
+287</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 296</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 284</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_translate'>translate</span><span class='lparen'>(</span><span class='id identifier rubyid_x'>x</span><span class='op'>=</span><span class='int'>1</span><span class='comma'>,</span> <span class='id identifier rubyid_y'>y</span><span class='op'>=</span><span class='int'>0</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise_if_negative'>raise_if_negative</span><span class='lparen'>(</span><span class='id identifier rubyid_x'>x</span><span class='comma'>,</span><span class='id identifier rubyid_y'>y</span><span class='rparen'>)</span>
@@ -6117,12 +6097,12 @@
       <pre class="lines">
 
 
-410
-411
-412</pre>
+398
+399
+400</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 410</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 398</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_weil_height'>weil_height</span>
   <span class='lbracket'>[</span><span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_max'>max</span>
@@ -6184,12 +6164,12 @@
       <pre class="lines">
 
 
-427
-428
-429</pre>
+415
+416
+417</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 427</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 415</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_wilson_height'>wilson_height</span><span class='lparen'>(</span><span class='label'>prime_rejects:</span> <span class='lbracket'>[</span><span class='int'>2</span><span class='rbracket'>]</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_benedetti_height'>benedetti_height</span><span class='period'>.</span><span class='id identifier rubyid_prime_division'>prime_division</span><span class='period'>.</span><span class='id identifier rubyid_reject'>reject</span><span class='lbrace'>{</span><span class='op'>|</span><span class='id identifier rubyid_p'>p</span><span class='op'>|</span> <span class='id identifier rubyid_prime_rejects'>prime_rejects</span><span class='period'>.</span><span class='id identifier rubyid_include?'>include?</span><span class='lparen'>(</span><span class='id identifier rubyid_p'>p</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span><span class='rparen'>)</span> <span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_sum'>sum</span><span class='lbrace'>{</span><span class='op'>|</span><span class='id identifier rubyid_p'>p</span><span class='op'>|</span> <span class='id identifier rubyid_p'>p</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span> <span class='op'>*</span> <span class='id identifier rubyid_p'>p</span><span class='period'>.</span><span class='id identifier rubyid_last'>last</span> <span class='rbrace'>}</span>
@@ -6236,12 +6216,12 @@
       <pre class="lines">
 
 
-383
-384
-385</pre>
+371
+372
+373</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 383</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 371</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_within_prime?'>within_prime?</span><span class='lparen'>(</span><span class='id identifier rubyid_prime'>prime</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_max_prime'>max_prime</span> <span class='op'>&lt;=</span> <span class='id identifier rubyid_prime'>prime</span>
@@ -6256,9 +6236,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Ratio/Approximation.html
+++ b/docs/Tonal/Ratio/Approximation.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Ratio::Approximation
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -1586,9 +1586,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Ratio/Approximation/Set.html
+++ b/docs/Tonal/Ratio/Approximation/Set.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Ratio::Approximation::Set
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -413,9 +413,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/ReducedRatio.html
+++ b/docs/Tonal/ReducedRatio.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::ReducedRatio
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -195,7 +195,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#interval_with-instance_method" title="#interval_with (instance method)">#<strong>interval_with</strong>(ratio)  &#x21d2; Interval </a>
+      <a href="#interval_with-instance_method" title="#interval_with (instance method)">#<strong>interval_with</strong>(ratio)  &#x21d2; Tonal::Interval </a>
     
 
     
@@ -211,6 +211,30 @@
   
     <span class="summary_desc"><div class='inline'>
 <p>Between self (upper) and ratio (lower).</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#invert!-instance_method" title="#invert! (instance method)">#<strong>invert!</strong>  &#x21d2; Tonal::ReducedRatio </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>With antecedent and precedent switched.</p>
 </div></span>
   
 </li>
@@ -253,7 +277,7 @@
   
   
   <h3 class="inherited">Methods inherited from <span class='object_link'><a href="Ratio.html" title="Tonal::Ratio (class)">Ratio</a></span></h3>
-  <p class="inherited"><span class='object_link'><a href="Ratio.html#*-instance_method" title="Tonal::Ratio#* (method)">#*</a></span>, <span class='object_link'><a href="Ratio.html#**-instance_method" title="Tonal::Ratio#** (method)">#**</a></span>, <span class='object_link'><a href="Ratio.html#%2B-instance_method" title="Tonal::Ratio#+ (method)">#+</a></span>, <span class='object_link'><a href="Ratio.html#--instance_method" title="Tonal::Ratio#- (method)">#-</a></span>, <span class='object_link'><a href="Ratio.html#%2F-instance_method" title="Tonal::Ratio#/ (method)">#/</a></span>, <span class='object_link'><a href="Ratio.html#<=>-instance_method" title="Tonal::Ratio#&lt;=&gt; (method)">#<=></a></span>, <span class='object_link'><a href="Ratio.html#approximate-instance_method" title="Tonal::Ratio#approximate (method)">#approximate</a></span>, <span class='object_link'><a href="Ratio.html#benedetti_height-instance_method" title="Tonal::Ratio#benedetti_height (method)">#benedetti_height</a></span>, <span class='object_link'><a href="Ratio.html#cent_diff-instance_method" title="Tonal::Ratio#cent_diff (method)">#cent_diff</a></span>, <span class='object_link'><a href="Ratio.html#combination-instance_method" title="Tonal::Ratio#combination (method)">#combination</a></span>, <span class='object_link'><a href="Ratio.html#difference-instance_method" title="Tonal::Ratio#difference (method)">#difference</a></span>, <span class='object_link'><a href="Ratio.html#div_times-instance_method" title="Tonal::Ratio#div_times (method)">#div_times</a></span>, <span class='object_link'><a href="Ratio.html#ed-class_method" title="Tonal::Ratio.ed (method)">ed</a></span>, <span class='object_link'><a href="Ratio.html#efficiency-instance_method" title="Tonal::Ratio#efficiency (method)">#efficiency</a></span>, <span class='object_link'><a href="Ratio.html#equave_reduce-instance_method" title="Tonal::Ratio#equave_reduce (method)">#equave_reduce</a></span>, <span class='object_link'><a href="Ratio.html#equave_reduce!-instance_method" title="Tonal::Ratio#equave_reduce! (method)">#equave_reduce!</a></span>, <span class='object_link'><a href="Ratio.html#fraction_reduce-instance_method" title="Tonal::Ratio#fraction_reduce (method)">#fraction_reduce</a></span>, <span class='object_link'><a href="Ratio.html#inspect-instance_method" title="Tonal::Ratio#inspect (method)">#inspect</a></span>, <span class='object_link'><a href="Ratio.html#invert-instance_method" title="Tonal::Ratio#invert (method)">#invert</a></span>, <span class='object_link'><a href="Ratio.html#invert!-instance_method" title="Tonal::Ratio#invert! (method)">#invert!</a></span>, <span class='object_link'><a href="Ratio.html#label-instance_method" title="Tonal::Ratio#label (method)">#label</a></span>, <span class='object_link'><a href="Ratio.html#lcm-instance_method" title="Tonal::Ratio#lcm (method)">#lcm</a></span>, <span class='object_link'><a href="Ratio.html#log_weil_height-instance_method" title="Tonal::Ratio#log_weil_height (method)">#log_weil_height</a></span>, <span class='object_link'><a href="Ratio.html#max_prime-instance_method" title="Tonal::Ratio#max_prime (method)">#max_prime</a></span>, <span class='object_link'><a href="Ratio.html#mediant_sum-instance_method" title="Tonal::Ratio#mediant_sum (method)">#mediant_sum</a></span>, <span class='object_link'><a href="Ratio.html#min_prime-instance_method" title="Tonal::Ratio#min_prime (method)">#min_prime</a></span>, <span class='object_link'><a href="Ratio.html#mirror-instance_method" title="Tonal::Ratio#mirror (method)">#mirror</a></span>, <span class='object_link'><a href="Ratio.html#negative-instance_method" title="Tonal::Ratio#negative (method)">#negative</a></span>, <span class='object_link'><a href="Ratio.html#period_degrees-instance_method" title="Tonal::Ratio#period_degrees (method)">#period_degrees</a></span>, <span class='object_link'><a href="Ratio.html#period_radians-instance_method" title="Tonal::Ratio#period_radians (method)">#period_radians</a></span>, <span class='object_link'><a href="Ratio.html#planar_degrees-instance_method" title="Tonal::Ratio#planar_degrees (method)">#planar_degrees</a></span>, <span class='object_link'><a href="Ratio.html#planar_radians-instance_method" title="Tonal::Ratio#planar_radians (method)">#planar_radians</a></span>, <span class='object_link'><a href="Ratio.html#plus_minus-instance_method" title="Tonal::Ratio#plus_minus (method)">#plus_minus</a></span>, <span class='object_link'><a href="Ratio.html#prime_divisions-instance_method" title="Tonal::Ratio#prime_divisions (method)">#prime_divisions</a></span>, <span class='object_link'><a href="Ratio.html#prime_vector-instance_method" title="Tonal::Ratio#prime_vector (method)">#prime_vector</a></span>, <span class='object_link'><a href="Ratio.html#random_ratio-class_method" title="Tonal::Ratio.random_ratio (method)">random_ratio</a></span>, <span class='object_link'><a href="Ratio.html#ratio-instance_method" title="Tonal::Ratio#ratio (method)">#ratio</a></span>, <span class='object_link'><a href="Ratio.html#scale-instance_method" title="Tonal::Ratio#scale (method)">#scale</a></span>, <span class='object_link'><a href="Ratio.html#shear-instance_method" title="Tonal::Ratio#shear (method)">#shear</a></span>, <span class='object_link'><a href="Ratio.html#step-instance_method" title="Tonal::Ratio#step (method)">#step</a></span>, <span class='object_link'><a href="Ratio.html#superparticular-class_method" title="Tonal::Ratio.superparticular (method)">superparticular</a></span>, <span class='object_link'><a href="Ratio.html#superpartient-class_method" title="Tonal::Ratio.superpartient (method)">superpartient</a></span>, <span class='object_link'><a href="Ratio.html#tenney_height-instance_method" title="Tonal::Ratio#tenney_height (method)">#tenney_height</a></span>, <span class='object_link'><a href="Ratio.html#to_a-instance_method" title="Tonal::Ratio#to_a (method)">#to_a</a></span>, <span class='object_link'><a href="Ratio.html#to_cents-instance_method" title="Tonal::Ratio#to_cents (method)">#to_cents</a></span>, <span class='object_link'><a href="Ratio.html#to_f-instance_method" title="Tonal::Ratio#to_f (method)">#to_f</a></span>, <span class='object_link'><a href="Ratio.html#to_log-instance_method" title="Tonal::Ratio#to_log (method)">#to_log</a></span>, <span class='object_link'><a href="Ratio.html#to_log2-instance_method" title="Tonal::Ratio#to_log2 (method)">#to_log2</a></span>, <span class='object_link'><a href="Ratio.html#to_r-instance_method" title="Tonal::Ratio#to_r (method)">#to_r</a></span>, <span class='object_link'><a href="Ratio.html#to_reduced_ratio-instance_method" title="Tonal::Ratio#to_reduced_ratio (method)">#to_reduced_ratio</a></span>, <span class='object_link'><a href="Ratio.html#to_v-instance_method" title="Tonal::Ratio#to_v (method)">#to_v</a></span>, <span class='object_link'><a href="Ratio.html#translate-instance_method" title="Tonal::Ratio#translate (method)">#translate</a></span>, <span class='object_link'><a href="Ratio.html#weil_height-instance_method" title="Tonal::Ratio#weil_height (method)">#weil_height</a></span>, <span class='object_link'><a href="Ratio.html#wilson_height-instance_method" title="Tonal::Ratio#wilson_height (method)">#wilson_height</a></span>, <span class='object_link'><a href="Ratio.html#within_cents%3F-class_method" title="Tonal::Ratio.within_cents? (method)">within_cents?</a></span>, <span class='object_link'><a href="Ratio.html#within_prime%3F-instance_method" title="Tonal::Ratio#within_prime? (method)">#within_prime?</a></span></p>
+  <p class="inherited"><span class='object_link'><a href="Ratio.html#*-instance_method" title="Tonal::Ratio#* (method)">#*</a></span>, <span class='object_link'><a href="Ratio.html#**-instance_method" title="Tonal::Ratio#** (method)">#**</a></span>, <span class='object_link'><a href="Ratio.html#%2B-instance_method" title="Tonal::Ratio#+ (method)">#+</a></span>, <span class='object_link'><a href="Ratio.html#--instance_method" title="Tonal::Ratio#- (method)">#-</a></span>, <span class='object_link'><a href="Ratio.html#%2F-instance_method" title="Tonal::Ratio#/ (method)">#/</a></span>, <span class='object_link'><a href="Ratio.html#<=>-instance_method" title="Tonal::Ratio#&lt;=&gt; (method)">#<=></a></span>, <span class='object_link'><a href="Ratio.html#approximate-instance_method" title="Tonal::Ratio#approximate (method)">#approximate</a></span>, <span class='object_link'><a href="Ratio.html#benedetti_height-instance_method" title="Tonal::Ratio#benedetti_height (method)">#benedetti_height</a></span>, <span class='object_link'><a href="Ratio.html#cent_diff-instance_method" title="Tonal::Ratio#cent_diff (method)">#cent_diff</a></span>, <span class='object_link'><a href="Ratio.html#combination-instance_method" title="Tonal::Ratio#combination (method)">#combination</a></span>, <span class='object_link'><a href="Ratio.html#difference-instance_method" title="Tonal::Ratio#difference (method)">#difference</a></span>, <span class='object_link'><a href="Ratio.html#div_times-instance_method" title="Tonal::Ratio#div_times (method)">#div_times</a></span>, <span class='object_link'><a href="Ratio.html#ed-class_method" title="Tonal::Ratio.ed (method)">ed</a></span>, <span class='object_link'><a href="Ratio.html#efficiency-instance_method" title="Tonal::Ratio#efficiency (method)">#efficiency</a></span>, <span class='object_link'><a href="Ratio.html#equave_reduce-instance_method" title="Tonal::Ratio#equave_reduce (method)">#equave_reduce</a></span>, <span class='object_link'><a href="Ratio.html#equave_reduce!-instance_method" title="Tonal::Ratio#equave_reduce! (method)">#equave_reduce!</a></span>, <span class='object_link'><a href="Ratio.html#fraction_reduce-instance_method" title="Tonal::Ratio#fraction_reduce (method)">#fraction_reduce</a></span>, <span class='object_link'><a href="Ratio.html#inspect-instance_method" title="Tonal::Ratio#inspect (method)">#inspect</a></span>, <span class='object_link'><a href="Ratio.html#invert-instance_method" title="Tonal::Ratio#invert (method)">#invert</a></span>, <span class='object_link'><a href="Ratio.html#label-instance_method" title="Tonal::Ratio#label (method)">#label</a></span>, <span class='object_link'><a href="Ratio.html#lcm-instance_method" title="Tonal::Ratio#lcm (method)">#lcm</a></span>, <span class='object_link'><a href="Ratio.html#log_weil_height-instance_method" title="Tonal::Ratio#log_weil_height (method)">#log_weil_height</a></span>, <span class='object_link'><a href="Ratio.html#max_prime-instance_method" title="Tonal::Ratio#max_prime (method)">#max_prime</a></span>, <span class='object_link'><a href="Ratio.html#mediant_sum-instance_method" title="Tonal::Ratio#mediant_sum (method)">#mediant_sum</a></span>, <span class='object_link'><a href="Ratio.html#min_prime-instance_method" title="Tonal::Ratio#min_prime (method)">#min_prime</a></span>, <span class='object_link'><a href="Ratio.html#mirror-instance_method" title="Tonal::Ratio#mirror (method)">#mirror</a></span>, <span class='object_link'><a href="Ratio.html#negative-instance_method" title="Tonal::Ratio#negative (method)">#negative</a></span>, <span class='object_link'><a href="Ratio.html#period_degrees-instance_method" title="Tonal::Ratio#period_degrees (method)">#period_degrees</a></span>, <span class='object_link'><a href="Ratio.html#period_radians-instance_method" title="Tonal::Ratio#period_radians (method)">#period_radians</a></span>, <span class='object_link'><a href="Ratio.html#planar_degrees-instance_method" title="Tonal::Ratio#planar_degrees (method)">#planar_degrees</a></span>, <span class='object_link'><a href="Ratio.html#planar_radians-instance_method" title="Tonal::Ratio#planar_radians (method)">#planar_radians</a></span>, <span class='object_link'><a href="Ratio.html#plus_minus-instance_method" title="Tonal::Ratio#plus_minus (method)">#plus_minus</a></span>, <span class='object_link'><a href="Ratio.html#prime_divisions-instance_method" title="Tonal::Ratio#prime_divisions (method)">#prime_divisions</a></span>, <span class='object_link'><a href="Ratio.html#prime_vector-instance_method" title="Tonal::Ratio#prime_vector (method)">#prime_vector</a></span>, <span class='object_link'><a href="Ratio.html#random_ratio-class_method" title="Tonal::Ratio.random_ratio (method)">random_ratio</a></span>, <span class='object_link'><a href="Ratio.html#ratio-instance_method" title="Tonal::Ratio#ratio (method)">#ratio</a></span>, <span class='object_link'><a href="Ratio.html#scale-instance_method" title="Tonal::Ratio#scale (method)">#scale</a></span>, <span class='object_link'><a href="Ratio.html#shear-instance_method" title="Tonal::Ratio#shear (method)">#shear</a></span>, <span class='object_link'><a href="Ratio.html#step-instance_method" title="Tonal::Ratio#step (method)">#step</a></span>, <span class='object_link'><a href="Ratio.html#superparticular-class_method" title="Tonal::Ratio.superparticular (method)">superparticular</a></span>, <span class='object_link'><a href="Ratio.html#superpartient-class_method" title="Tonal::Ratio.superpartient (method)">superpartient</a></span>, <span class='object_link'><a href="Ratio.html#tenney_height-instance_method" title="Tonal::Ratio#tenney_height (method)">#tenney_height</a></span>, <span class='object_link'><a href="Ratio.html#to_a-instance_method" title="Tonal::Ratio#to_a (method)">#to_a</a></span>, <span class='object_link'><a href="Ratio.html#to_cents-instance_method" title="Tonal::Ratio#to_cents (method)">#to_cents</a></span>, <span class='object_link'><a href="Ratio.html#to_f-instance_method" title="Tonal::Ratio#to_f (method)">#to_f</a></span>, <span class='object_link'><a href="Ratio.html#to_log-instance_method" title="Tonal::Ratio#to_log (method)">#to_log</a></span>, <span class='object_link'><a href="Ratio.html#to_log2-instance_method" title="Tonal::Ratio#to_log2 (method)">#to_log2</a></span>, <span class='object_link'><a href="Ratio.html#to_r-instance_method" title="Tonal::Ratio#to_r (method)">#to_r</a></span>, <span class='object_link'><a href="Ratio.html#to_reduced_ratio-instance_method" title="Tonal::Ratio#to_reduced_ratio (method)">#to_reduced_ratio</a></span>, <span class='object_link'><a href="Ratio.html#to_v-instance_method" title="Tonal::Ratio#to_v (method)">#to_v</a></span>, <span class='object_link'><a href="Ratio.html#translate-instance_method" title="Tonal::Ratio#translate (method)">#translate</a></span>, <span class='object_link'><a href="Ratio.html#weil_height-instance_method" title="Tonal::Ratio#weil_height (method)">#weil_height</a></span>, <span class='object_link'><a href="Ratio.html#wilson_height-instance_method" title="Tonal::Ratio#wilson_height (method)">#wilson_height</a></span>, <span class='object_link'><a href="Ratio.html#within_cents%3F-class_method" title="Tonal::Ratio.within_cents? (method)">within_cents?</a></span>, <span class='object_link'><a href="Ratio.html#within_prime%3F-instance_method" title="Tonal::Ratio#within_prime? (method)">#within_prime?</a></span></p>
 
   
   <div id="constructor_details" class="method_details_list">
@@ -400,7 +424,7 @@
       <div class="method_details first">
   <h3 class="signature first" id="interval_with-instance_method">
   
-    #<strong>interval_with</strong>(ratio)  &#x21d2; <tt><span class='object_link'><a href="Interval.html" title="Tonal::Interval (class)">Interval</a></span></tt> 
+    #<strong>interval_with</strong>(ratio)  &#x21d2; <tt><span class='object_link'><a href="Interval.html" title="Tonal::Interval (class)">Tonal::Interval</a></span></tt> 
   
 
   
@@ -445,7 +469,7 @@
     <li>
       
       
-        <span class='type'>(<tt><span class='object_link'><a href="Interval.html" title="Tonal::Interval (class)">Interval</a></span></tt>)</span>
+        <span class='type'>(<tt><span class='object_link'><a href="Interval.html" title="Tonal::Interval (class)">Tonal::Interval</a></span></tt>)</span>
       
       
       
@@ -475,6 +499,77 @@
 <span class='kw'>def</span> <span class='id identifier rubyid_interval_with'>interval_with</span><span class='lparen'>(</span><span class='id identifier rubyid_ratio'>ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_r'>r</span> <span class='op'>=</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span><span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='rparen'>)</span> <span class='op'>?</span> <span class='id identifier rubyid_ratio'>ratio</span> <span class='op'>:</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_ratio'>ratio</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Interval.html" title="Tonal::Interval (class)">Interval</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Interval.html#initialize-instance_method" title="Tonal::Interval#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='kw'>self</span><span class='comma'>,</span> <span class='id identifier rubyid_r'>r</span><span class='rparen'>)</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="invert!-instance_method">
+  
+    #<strong>invert!</strong>  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::ReducedRatio (class)">Tonal::ReducedRatio</a></span></tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns with antecedent and precedent switched.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+  <div class="examples">
+    <p class="tag_title">Examples:</p>
+    
+      
+      <pre class="example code"><code>Tonal::ReducedRatio.new(3,2).invert! =&gt; (4/3)</code></pre>
+    
+  </div>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="" title="Tonal::ReducedRatio (class)">Tonal::ReducedRatio</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>with antecedent and precedent switched</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+42
+43
+44
+45
+46</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/tonal/reduced_ratio.rb', line 42</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_invert!'>invert!</span>
+  <span class='kw'>super</span>
+  <span class='ivar'>@antecedent</span><span class='comma'>,</span> <span class='ivar'>@consequent</span> <span class='op'>=</span> <span class='ivar'>@reduced_antecedent</span><span class='comma'>,</span> <span class='ivar'>@reduced_consequent</span>
+  <span class='kw'>self</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -553,9 +648,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:45 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Tonal/Step.html
+++ b/docs/Tonal/Step.html
@@ -6,7 +6,7 @@
 <title>
   Class: Tonal::Step
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -323,7 +323,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#convert-instance_method" title="#convert (instance method)">#<strong>convert</strong>(new_modulo)  &#x21d2; Object </a>
+      <a href="#convert-instance_method" title="#convert (instance method)">#<strong>convert</strong>(new_modulo)  &#x21d2; Tonal::Step </a>
     
 
     
@@ -337,7 +337,33 @@
   
 
   
-    <span class="summary_desc"><div class='inline'></div></span>
+    <span class="summary_desc"><div class='inline'>
+<p>New step with the ratio mapped to the new modulo.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#efficiency-instance_method" title="#efficiency (instance method)">#<strong>efficiency</strong>  &#x21d2; Tonal::Cents </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>The difference between the step and the ratio.</p>
+</div></span>
   
 </li>
 
@@ -395,7 +421,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#to_cents-instance_method" title="#to_cents (instance method)">#<strong>to_cents</strong>  &#x21d2; Object </a>
+      <a href="#ratio_to_cents-instance_method" title="#ratio_to_cents (instance method)">#<strong>ratio_to_cents</strong>  &#x21d2; Tonal::Cents </a>
     
 
     
@@ -409,7 +435,9 @@
   
 
   
-    <span class="summary_desc"><div class='inline'></div></span>
+    <span class="summary_desc"><div class='inline'>
+<p>Measure of ratio in cents.</p>
+</div></span>
   
 </li>
 
@@ -417,7 +445,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#to_r-instance_method" title="#to_r (instance method)">#<strong>to_r</strong>  &#x21d2; Object </a>
+      <a href="#ratio_to_r-instance_method" title="#ratio_to_r (instance method)">#<strong>ratio_to_r</strong>  &#x21d2; Rational </a>
     
 
     
@@ -431,7 +459,61 @@
   
 
   
-    <span class="summary_desc"><div class='inline'></div></span>
+    <span class="summary_desc"><div class='inline'>
+<p>Of the ratio.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#step_to_cents-instance_method" title="#step_to_cents (instance method)">#<strong>step_to_cents</strong>  &#x21d2; Tonal::Cents </a>
+    
+
+    
+      (also: #to_cents)
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Measure of step in cents.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#step_to_r-instance_method" title="#step_to_r (instance method)">#<strong>step_to_r</strong>  &#x21d2; Rational </a>
+    
+
+    
+      (also: #to_r)
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>Of the step.</p>
+</div></span>
   
 </li>
 
@@ -770,12 +852,12 @@
       <pre class="lines">
 
 
-43
-44
-45</pre>
+87
+88
+89</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 43</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 87</span>
 
 <span class='kw'>def</span> <span class='op'>+</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='label'>step:</span> <span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span> <span class='op'>%</span> <span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='label'>modulo:</span> <span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span>
@@ -800,12 +882,12 @@
       <pre class="lines">
 
 
-48
-49
-50</pre>
+92
+93
+94</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 48</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 92</span>
 
 <span class='kw'>def</span> <span class='op'>&lt;=&gt;</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_kind_of?'>kind_of?</span><span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='rparen'>)</span> <span class='op'>&amp;&amp;</span> <span class='id identifier rubyid_modulo'>modulo</span> <span class='op'>&lt;=&gt;</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_modulo'>modulo</span> <span class='op'>&amp;&amp;</span> <span class='id identifier rubyid_log'>log</span> <span class='op'>&lt;=&gt;</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_log'>log</span> <span class='op'>&amp;&amp;</span> <span class='id identifier rubyid_step'>step</span> <span class='op'>&lt;=&gt;</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_step'>step</span>
@@ -818,27 +900,133 @@
       <div class="method_details ">
   <h3 class="signature " id="convert-instance_method">
   
-    #<strong>convert</strong>(new_modulo)  &#x21d2; <tt>Object</tt> 
+    #<strong>convert</strong>(new_modulo)  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Step (class)">Tonal::Step</a></span></tt> 
   
 
   
 
   
-</h3><table class="source_code">
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns new step with the ratio mapped to the new modulo.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+  <div class="examples">
+    <p class="tag_title">Examples:</p>
+    
+      
+      <pre class="example code"><code>Tonal::Step.new(ratio: 3/2r, modulo: 31).convert(12)
+=&gt; 7\12</code></pre>
+    
+  </div>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="" title="Tonal::Step (class)">Tonal::Step</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>new step with the ratio mapped to the new modulo</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
   <tr>
     <td>
       <pre class="lines">
 
 
-31
-32
-33</pre>
+36
+37
+38</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 31</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 36</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_convert'>convert</span><span class='lparen'>(</span><span class='id identifier rubyid_new_modulo'>new_modulo</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='label'>log:</span> <span class='id identifier rubyid_log'>log</span><span class='comma'>,</span> <span class='label'>modulo:</span> <span class='id identifier rubyid_new_modulo'>new_modulo</span><span class='rparen'>)</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="efficiency-instance_method">
+  
+    #<strong>efficiency</strong>  &#x21d2; <tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns the difference between the step and the ratio.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+  <div class="examples">
+    <p class="tag_title">Examples:</p>
+    
+      
+      <pre class="example code"><code>Tonal::Step.new(ratio: 3/2r, modulo: 31).efficiency
+=&gt; 5.19</code></pre>
+    
+  </div>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>the difference between the step and the ratio</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+83
+84
+85</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 83</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_efficiency'>efficiency</span>
+  <span class='id identifier rubyid_ratio_to_cents'>ratio_to_cents</span> <span class='op'>-</span> <span class='id identifier rubyid_step_to_cents'>step_to_cents</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -880,28 +1068,66 @@
 </div>
     
       <div class="method_details ">
-  <h3 class="signature " id="to_cents-instance_method">
+  <h3 class="signature " id="ratio_to_cents-instance_method">
   
-    #<strong>to_cents</strong>  &#x21d2; <tt>Object</tt> 
-  
-
+    #<strong>ratio_to_cents</strong>  &#x21d2; <tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt> 
   
 
   
-</h3><table class="source_code">
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns measure of ratio in cents.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+  <div class="examples">
+    <p class="tag_title">Examples:</p>
+    
+      
+      <pre class="example code"><code>Tonal::Step.new(ratio: 3/2r, modulo: 31).ratio_to_cents
+=&gt; 701.96</code></pre>
+    
+  </div>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>measure of ratio in cents</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
   <tr>
     <td>
       <pre class="lines">
 
 
-39
-40
-41</pre>
+74
+75
+76</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 39</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 74</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_to_cents'>to_cents</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_ratio_to_cents'>ratio_to_cents</span>
   <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_to_cents'>to_cents</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -910,29 +1136,211 @@
 </div>
     
       <div class="method_details ">
-  <h3 class="signature " id="to_r-instance_method">
+  <h3 class="signature " id="ratio_to_r-instance_method">
   
-    #<strong>to_r</strong>  &#x21d2; <tt>Object</tt> 
-  
-
+    #<strong>ratio_to_r</strong>  &#x21d2; <tt>Rational</tt> 
   
 
   
-</h3><table class="source_code">
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns of the ratio.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+  <div class="examples">
+    <p class="tag_title">Examples:</p>
+    
+      
+      <pre class="example code"><code>Tonal::Step.new(ratio: 3/2r, modulo: 31).ratio_to_r
+=&gt; 3/2</code></pre>
+    
+  </div>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Rational</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>of the ratio</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
   <tr>
     <td>
       <pre class="lines">
 
 
-35
-36
-37</pre>
+55
+56
+57</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 35</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 55</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_to_r'>to_r</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_ratio_to_r'>ratio_to_r</span>
   <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_to_r'>to_r</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="step_to_cents-instance_method">
+  
+    #<strong>step_to_cents</strong>  &#x21d2; <tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt> 
+  
+
+  
+    <span class="aliases">Also known as:
+    <span class="names"><span id='to_cents-instance_method'>to_cents</span></span>
+    </span>
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns measure of step in cents.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+  <div class="examples">
+    <p class="tag_title">Examples:</p>
+    
+      
+      <pre class="example code"><code>Tonal::Step.new(ratio: 3/2r, modulo: 31).step_to_cents
+=&gt; 696.77</code></pre>
+    
+  </div>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Tonal::Cents</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>measure of step in cents</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+64
+65
+66</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 64</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_step_to_cents'>step_to_cents</span>
+  <span class='id identifier rubyid_tempered'>tempered</span><span class='period'>.</span><span class='id identifier rubyid_to_cents'>to_cents</span>
+<span class='kw'>end</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
+  <h3 class="signature " id="step_to_r-instance_method">
+  
+    #<strong>step_to_r</strong>  &#x21d2; <tt>Rational</tt> 
+  
+
+  
+    <span class="aliases">Also known as:
+    <span class="names"><span id='to_r-instance_method'>to_r</span></span>
+    </span>
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns of the step.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+  <div class="examples">
+    <p class="tag_title">Examples:</p>
+    
+      
+      <pre class="example code"><code>Tonal::Step.new(ratio: 3/2r, modulo: 31).step_to_r
+=&gt; 6735213777669305/4503599627370496</code></pre>
+    
+  </div>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt>Rational</tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>of the step</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+45
+46
+47</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/tonal/step.rb', line 45</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_step_to_r'>step_to_r</span>
+  <span class='id identifier rubyid_tempered'>tempered</span><span class='period'>.</span><span class='id identifier rubyid_to_r'>to_r</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -944,9 +1352,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/Vector.html
+++ b/docs/Vector.html
@@ -6,7 +6,7 @@
 <title>
   Class: Vector
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -242,9 +242,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>
-  Documentation by YARD 0.9.34
+  Documentation by YARD 0.9.36
   
 </title>
 
@@ -52,7 +52,7 @@
         <div class="clear"></div>
       </div>
 
-      <div id="content"><h1 class="noborder title">Documentation by YARD 0.9.34</h1>
+      <div id="content"><h1 class="noborder title">Documentation by YARD 0.9.36</h1>
 <div id="listing">
   <h1 class="alphaindex">Alphabetic Index</h1>
   
@@ -295,9 +295,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:04 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -6,7 +6,7 @@
 <title>
   File: README
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -79,9 +79,9 @@
 </div></div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/frames.html
+++ b/docs/frames.html
@@ -2,13 +2,18 @@
 <html>
 <head>
   <meta charset="utf-8">
-	<title>Documentation by YARD 0.9.34</title>
+	<title>Documentation by YARD 0.9.36</title>
 </head>
 <script type="text/javascript">
-  var match = unescape(window.location.hash).match(/^#!(.+)/);
-  var name = match ? match[1] : 'index.html';
-  name = name.replace(/^(\w+):\/\//, '').replace(/^\/\//, '');
-  window.top.location = name;
+var mainUrl = 'index.html';
+try {
+    var match = decodeURIComponent(window.location.hash).match(/^#!(.+)/);
+    var name = match ? match[1] : mainUrl;
+    var url = new URL(name, location.href);
+    window.top.location.replace(url.origin === location.origin ? name : mainUrl);
+} catch (e) {
+    window.top.location.replace(mainUrl);
+}
 </script>
 <noscript>
   <h1>Oops!</h1>

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
 <title>
   File: README
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -79,9 +79,9 @@
 </div></div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/docs/method_list.html
+++ b/docs/method_list.html
@@ -62,16 +62,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#%2B-instance_method" title="Tonal::Ratio#+ (method)">#+</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Tonal/Step.html#%2B-instance_method" title="Tonal::Step#+ (method)">#+</a></span>
+      <small>Tonal::Step</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#%2B-instance_method" title="Tonal::Step#+ (method)">#+</a></span>
-      <small>Tonal::Step</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#%2B-instance_method" title="Tonal::Ratio#+ (method)">#+</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -94,32 +94,32 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#<=>-instance_method" title="Tonal::Log#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Tonal::Log</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Interval.html#<=>-instance_method" title="Tonal::Interval#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
       <small>Tonal::Interval</small>
     </div>
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Cents.html#<=>-instance_method" title="Tonal::Cents#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Tonal::Cents</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#<=>-instance_method" title="Tonal::Step#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Tonal::Step</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#<=>-instance_method" title="Tonal::Ratio#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#<=>-instance_method" title="Tonal::Ratio#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Tonal/Log.html#<=>-instance_method" title="Tonal::Log#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Tonal::Log</small>
     </div>
   </li>
   
@@ -134,8 +134,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Cents.html#<=>-instance_method" title="Tonal::Cents#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Tonal::Cents</small>
+      <span class='object_link'><a href="Tonal/Step.html#<=>-instance_method" title="Tonal::Step#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Tonal::Step</small>
     </div>
   </li>
   
@@ -190,16 +190,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#benedetti_height-instance_method" title="Numeric#benedetti_height (method)">#benedetti_height</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#benedetti_height-instance_method" title="Tonal::Ratio#benedetti_height (method)">#benedetti_height</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#benedetti_height-instance_method" title="Tonal::Ratio#benedetti_height (method)">#benedetti_height</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Numeric.html#benedetti_height-instance_method" title="Numeric#benedetti_height (method)">#benedetti_height</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
@@ -326,16 +326,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#denominize-instance_method" title="Tonal::Interval#denominize (method)">#denominize</a></span>
-      <small>Tonal::Interval</small>
+      <span class='object_link'><a href="Array.html#denominize-instance_method" title="Array#denominize (method)">#denominize</a></span>
+      <small>Array</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Array.html#denominize-instance_method" title="Array#denominize (method)">#denominize</a></span>
-      <small>Array</small>
+      <span class='object_link'><a href="Tonal/Interval.html#denominize-instance_method" title="Tonal::Interval#denominize (method)">#denominize</a></span>
+      <small>Tonal::Interval</small>
     </div>
   </li>
   
@@ -350,16 +350,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#div_times-instance_method" title="Numeric#div_times (method)">#div_times</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#div_times-instance_method" title="Tonal::Ratio#div_times (method)">#div_times</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#div_times-instance_method" title="Tonal::Ratio#div_times (method)">#div_times</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Numeric.html#div_times-instance_method" title="Numeric#div_times (method)">#div_times</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
@@ -382,13 +382,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/Step.html#efficiency-instance_method" title="Tonal::Step#efficiency (method)">#efficiency</a></span>
+      <small>Tonal::Step</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Numeric.html#efficiency-instance_method" title="Numeric#efficiency (method)">#efficiency</a></span>
       <small>Numeric</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#equave-instance_method" title="Tonal::Ratio#equave (method)">#equave</a></span>
       <small>Tonal::Ratio</small>
@@ -396,7 +404,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#equave_reduce-instance_method" title="Tonal::Ratio#equave_reduce (method)">#equave_reduce</a></span>
       <small>Tonal::Ratio</small>
@@ -404,18 +412,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#equave_reduce!-instance_method" title="Tonal::Ratio#equave_reduce! (method)">#equave_reduce!</a></span>
       <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Integer.html#factorial-instance_method" title="Integer#factorial (method)">#factorial</a></span>
-      <small>Integer</small>
     </div>
   </li>
   
@@ -430,13 +430,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Integer.html#factorial-instance_method" title="Integer#factorial (method)">#factorial</a></span>
+      <small>Integer</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#fraction_reduce-instance_method" title="Tonal::Ratio#fraction_reduce (method)">#fraction_reduce</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#hz-instance_method" title="Numeric#hz (method)">#hz</a></span>
       <small>Numeric</small>
@@ -444,7 +452,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/ReducedRatio.html#identity-class_method" title="Tonal::ReducedRatio.identity (method)">identity</a></span>
       <small>Tonal::ReducedRatio</small>
@@ -452,7 +460,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">#initialize</a></span>
       <small>Tonal::Cents</small>
@@ -460,50 +468,10 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">#initialize</a></span>
-      <small>Tonal::ReducedRatio</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">#initialize</a></span>
-      <small>Tonal::Log</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#initialize-instance_method" title="Tonal::Ratio::Approximation::Set#initialize (method)">#initialize</a></span>
-      <small>Tonal::Ratio::Approximation::Set</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio/Approximation.html#initialize-instance_method" title="Tonal::Ratio::Approximation#initialize (method)">#initialize</a></span>
-      <small>Tonal::Ratio::Approximation</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Hertz.html#initialize-instance_method" title="Tonal::Hertz#initialize (method)">#initialize</a></span>
-      <small>Tonal::Hertz</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#initialize-instance_method" title="Tonal::Interval#initialize (method)">#initialize</a></span>
-      <small>Tonal::Interval</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#initialize-instance_method" title="Tonal::Ratio#initialize (method)">#initialize</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -518,7 +486,87 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#initialize-instance_method" title="Tonal::Ratio#initialize (method)">#initialize</a></span>
+      <span class='object_link'><a href="Tonal/Hertz.html#initialize-instance_method" title="Tonal::Hertz#initialize (method)">#initialize</a></span>
+      <small>Tonal::Hertz</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio/Approximation.html#initialize-instance_method" title="Tonal::Ratio::Approximation#initialize (method)">#initialize</a></span>
+      <small>Tonal::Ratio::Approximation</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Interval.html#initialize-instance_method" title="Tonal::Interval#initialize (method)">#initialize</a></span>
+      <small>Tonal::Interval</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">#initialize</a></span>
+      <small>Tonal::Log</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#initialize-instance_method" title="Tonal::Ratio::Approximation::Set#initialize (method)">#initialize</a></span>
+      <small>Tonal::Ratio::Approximation::Set</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">#initialize</a></span>
+      <small>Tonal::ReducedRatio</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Hertz.html#inspect-instance_method" title="Tonal::Hertz#inspect (method)">#inspect</a></span>
+      <small>Tonal::Hertz</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Interval.html#inspect-instance_method" title="Tonal::Interval#inspect (method)">#inspect</a></span>
+      <small>Tonal::Interval</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Log.html#inspect-instance_method" title="Tonal::Log#inspect (method)">#inspect</a></span>
+      <small>Tonal::Log</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#inspect-instance_method" title="Tonal::Ratio::Approximation::Set#inspect (method)">#inspect</a></span>
+      <small>Tonal::Ratio::Approximation::Set</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#inspect-instance_method" title="Tonal::Ratio#inspect (method)">#inspect</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
@@ -534,64 +582,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Hertz.html#inspect-instance_method" title="Tonal::Hertz#inspect (method)">#inspect</a></span>
-      <small>Tonal::Hertz</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#inspect-instance_method" title="Tonal::Step#inspect (method)">#inspect</a></span>
       <small>Tonal::Step</small>
     </div>
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#inspect-instance_method" title="Tonal::Interval#inspect (method)">#inspect</a></span>
-      <small>Tonal::Interval</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#inspect-instance_method" title="Tonal::Ratio#inspect (method)">#inspect</a></span>
-      <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#inspect-instance_method" title="Tonal::Ratio::Approximation::Set#inspect (method)">#inspect</a></span>
-      <small>Tonal::Ratio::Approximation::Set</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#inspect-instance_method" title="Tonal::Log#inspect (method)">#inspect</a></span>
-      <small>Tonal::Log</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Interval.html#interval-instance_method" title="Tonal::Interval#interval (method)">#interval</a></span>
       <small>Tonal::Interval</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/ReducedRatio.html#interval_with-instance_method" title="Tonal::ReducedRatio#interval_with (method)">#interval_with</a></span>
-      <small>Tonal::ReducedRatio</small>
     </div>
   </li>
   
@@ -606,7 +606,23 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/ReducedRatio.html#interval_with-instance_method" title="Tonal::ReducedRatio#interval_with (method)">#interval_with</a></span>
+      <small>Tonal::ReducedRatio</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#invert-instance_method" title="Tonal::Ratio#invert (method)">#invert</a></span>
+      <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#invert!-instance_method" title="Tonal::Ratio#invert! (method)">#invert!</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
@@ -614,8 +630,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#invert!-instance_method" title="Tonal::Ratio#invert! (method)">#invert!</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Tonal/ReducedRatio.html#invert!-instance_method" title="Tonal::ReducedRatio#invert! (method)">#invert!</a></span>
+      <small>Tonal::ReducedRatio</small>
     </div>
   </li>
   
@@ -662,16 +678,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#log-instance_method" title="Tonal::Step#log (method)">#log</a></span>
-      <small>Tonal::Step</small>
+      <span class='object_link'><a href="Tonal/Cents.html#log-instance_method" title="Tonal::Cents#log (method)">#log</a></span>
+      <small>Tonal::Cents</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Cents.html#log-instance_method" title="Tonal::Cents#log (method)">#log</a></span>
-      <small>Tonal::Cents</small>
+      <span class='object_link'><a href="Tonal/Step.html#log-instance_method" title="Tonal::Step#log (method)">#log</a></span>
+      <small>Tonal::Step</small>
     </div>
   </li>
   
@@ -686,16 +702,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#log_weil_height-instance_method" title="Tonal::Ratio#log_weil_height (method)">#log_weil_height</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Numeric.html#log_weil_height-instance_method" title="Numeric#log_weil_height (method)">#log_weil_height</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#log_weil_height-instance_method" title="Numeric#log_weil_height (method)">#log_weil_height</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#log_weil_height-instance_method" title="Tonal::Ratio#log_weil_height (method)">#log_weil_height</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -726,24 +742,24 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#max_prime-instance_method" title="Tonal::Ratio#max_prime (method)">#max_prime</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Integer.html#max_prime-instance_method" title="Integer#max_prime (method)">#max_prime</a></span>
+      <small>Integer</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#max_prime-instance_method" title="Numeric#max_prime (method)">#max_prime</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#max_prime-instance_method" title="Tonal::Ratio#max_prime (method)">#max_prime</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Integer.html#max_prime-instance_method" title="Integer#max_prime (method)">#max_prime</a></span>
-      <small>Integer</small>
+      <span class='object_link'><a href="Numeric.html#max_prime-instance_method" title="Numeric#max_prime (method)">#max_prime</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
@@ -766,32 +782,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Comma.html#method_missing-class_method" title="Tonal::Comma.method_missing (method)">method_missing</a></span>
-      <small>Tonal::Comma</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Hertz.html#method_missing-instance_method" title="Tonal::Hertz#method_missing (method)">#method_missing</a></span>
       <small>Tonal::Hertz</small>
     </div>
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Integer.html#min_prime-instance_method" title="Integer#min_prime (method)">#min_prime</a></span>
-      <small>Integer</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#min_prime-instance_method" title="Numeric#min_prime (method)">#min_prime</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Comma.html#method_missing-class_method" title="Tonal::Comma.method_missing (method)">method_missing</a></span>
+      <small>Tonal::Comma</small>
     </div>
   </li>
   
@@ -800,6 +800,22 @@
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#min_prime-instance_method" title="Tonal::Ratio#min_prime (method)">#min_prime</a></span>
       <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Integer.html#min_prime-instance_method" title="Integer#min_prime (method)">#min_prime</a></span>
+      <small>Integer</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Numeric.html#min_prime-instance_method" title="Numeric#min_prime (method)">#min_prime</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
@@ -862,16 +878,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#negative-instance_method" title="Tonal::Ratio#negative (method)">#negative</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Numeric.html#negative-instance_method" title="Numeric#negative (method)">#negative</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#negative-instance_method" title="Numeric#negative (method)">#negative</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#negative-instance_method" title="Tonal::Ratio#negative (method)">#negative</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -910,16 +926,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#period_degrees-instance_method" title="Tonal::Ratio#period_degrees (method)">#period_degrees</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Numeric.html#period_degrees-instance_method" title="Numeric#period_degrees (method)">#period_degrees</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#period_degrees-instance_method" title="Numeric#period_degrees (method)">#period_degrees</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#period_degrees-instance_method" title="Tonal::Ratio#period_degrees (method)">#period_degrees</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -958,8 +974,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#plus_minus-instance_method" title="Tonal::Ratio#plus_minus (method)">#plus_minus</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Tonal/Cents.html#plus_minus-instance_method" title="Tonal::Cents#plus_minus (method)">#plus_minus</a></span>
+      <small>Tonal::Cents</small>
     </div>
   </li>
   
@@ -974,24 +990,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Cents.html#plus_minus-instance_method" title="Tonal::Cents#plus_minus (method)">#plus_minus</a></span>
-      <small>Tonal::Cents</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#plus_minus-instance_method" title="Tonal::Ratio#plus_minus (method)">#plus_minus</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#prime_divisions-instance_method" title="Tonal::Ratio#prime_divisions (method)">#prime_divisions</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Numeric.html#prime_divisions-instance_method" title="Numeric#prime_divisions (method)">#prime_divisions</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#prime_divisions-instance_method" title="Numeric#prime_divisions (method)">#prime_divisions</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#prime_divisions-instance_method" title="Tonal::Ratio#prime_divisions (method)">#prime_divisions</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -1022,22 +1038,6 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Cents.html#ratio-instance_method" title="Tonal::Cents#ratio (method)">#ratio</a></span>
-      <small>Tonal::Cents</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#ratio-instance_method" title="Tonal::Step#ratio (method)">#ratio</a></span>
-      <small>Tonal::Step</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#ratio-instance_method" title="Tonal::Ratio::Approximation::Set#ratio (method)">#ratio</a></span>
       <small>Tonal::Ratio::Approximation::Set</small>
     </div>
@@ -1046,8 +1046,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio/Approximation.html#ratio-instance_method" title="Tonal::Ratio::Approximation#ratio (method)">#ratio</a></span>
-      <small>Tonal::Ratio::Approximation</small>
+      <span class='object_link'><a href="Tonal/Cents.html#ratio-instance_method" title="Tonal::Cents#ratio (method)">#ratio</a></span>
+      <small>Tonal::Cents</small>
     </div>
   </li>
   
@@ -1062,8 +1062,40 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/Step.html#ratio-instance_method" title="Tonal::Step#ratio (method)">#ratio</a></span>
+      <small>Tonal::Step</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio/Approximation.html#ratio-instance_method" title="Tonal::Ratio::Approximation#ratio (method)">#ratio</a></span>
+      <small>Tonal::Ratio::Approximation</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Array.html#ratio_from_prime_divisions-instance_method" title="Array#ratio_from_prime_divisions (method)">#ratio_from_prime_divisions</a></span>
       <small>Array</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Step.html#ratio_to_cents-instance_method" title="Tonal::Step#ratio_to_cents (method)">#ratio_to_cents</a></span>
+      <small>Tonal::Step</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Step.html#ratio_to_r-instance_method" title="Tonal::Step#ratio_to_r (method)">#ratio_to_r</a></span>
+      <small>Tonal::Step</small>
     </div>
   </li>
   
@@ -1134,6 +1166,22 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/Step.html#step-instance_method" title="Tonal::Step#step (method)">#step</a></span>
+      <small>Tonal::Step</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Log.html#step-instance_method" title="Tonal::Log#step (method)">#step</a></span>
+      <small>Tonal::Log</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#step-instance_method" title="Tonal::Ratio#step (method)">#step</a></span>
       <small>Tonal::Ratio</small>
     </div>
@@ -1150,7 +1198,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#step-instance_method" title="Tonal::Step#step (method)">#step</a></span>
+      <span class='object_link'><a href="Tonal/Step.html#step_to_cents-instance_method" title="Tonal::Step#step_to_cents (method)">#step_to_cents</a></span>
       <small>Tonal::Step</small>
     </div>
   </li>
@@ -1158,8 +1206,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#step-instance_method" title="Tonal::Log#step (method)">#step</a></span>
-      <small>Tonal::Log</small>
+      <span class='object_link'><a href="Tonal/Step.html#step_to_r-instance_method" title="Tonal::Step#step_to_r (method)">#step_to_r</a></span>
+      <small>Tonal::Step</small>
     </div>
   </li>
   
@@ -1230,8 +1278,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Array.html#to_cents-instance_method" title="Array#to_cents (method)">#to_cents</a></span>
-      <small>Array</small>
+      <span class='object_link'><a href="Numeric.html#to_cents-instance_method" title="Numeric#to_cents (method)">#to_cents</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
@@ -1246,32 +1294,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#to_cents-instance_method" title="Tonal::Step#to_cents (method)">#to_cents</a></span>
-      <small>Tonal::Step</small>
+      <span class='object_link'><a href="Array.html#to_cents-instance_method" title="Array#to_cents (method)">#to_cents</a></span>
+      <small>Array</small>
     </div>
   </li>
   
 
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Numeric.html#to_cents-instance_method" title="Numeric#to_cents (method)">#to_cents</a></span>
-      <small>Numeric</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Log.html#to_cents-instance_method" title="Tonal::Log#to_cents (method)">#to_cents</a></span>
       <small>Tonal::Log</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#to_f-instance_method" title="Tonal::Ratio#to_f (method)">#to_f</a></span>
-      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -1286,7 +1318,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#to_log-instance_method" title="Tonal::Ratio#to_log (method)">#to_log</a></span>
+      <span class='object_link'><a href="Tonal/Ratio.html#to_f-instance_method" title="Tonal::Ratio#to_f (method)">#to_f</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
@@ -1294,7 +1326,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#to_log2-instance_method" title="Tonal::Ratio#to_log2 (method)">#to_log2</a></span>
+      <span class='object_link'><a href="Tonal/Ratio.html#to_log-instance_method" title="Tonal::Ratio#to_log (method)">#to_log</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
@@ -1302,8 +1334,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#to_r-instance_method" title="Tonal::Step#to_r (method)">#to_r</a></span>
-      <small>Tonal::Step</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#to_log2-instance_method" title="Tonal::Ratio#to_log2 (method)">#to_log2</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -1326,16 +1358,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#to_ratio-instance_method" title="Numeric#to_ratio (method)">#to_ratio</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Vector.html#to_ratio-instance_method" title="Vector#to_ratio (method)">#to_ratio</a></span>
+      <small>Vector</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Vector.html#to_ratio-instance_method" title="Vector#to_ratio (method)">#to_ratio</a></span>
-      <small>Vector</small>
+      <span class='object_link'><a href="Numeric.html#to_ratio-instance_method" title="Numeric#to_ratio (method)">#to_ratio</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
@@ -1422,32 +1454,32 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#weil_height-instance_method" title="Tonal::Ratio#weil_height (method)">#weil_height</a></span>
-      <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Numeric.html#weil_height-instance_method" title="Numeric#weil_height (method)">#weil_height</a></span>
       <small>Numeric</small>
     </div>
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#weil_height-instance_method" title="Tonal::Ratio#weil_height (method)">#weil_height</a></span>
+      <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#wilson_height-instance_method" title="Tonal::Ratio#wilson_height (method)">#wilson_height</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Numeric.html#wilson_height-instance_method" title="Numeric#wilson_height (method)">#wilson_height</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#wilson_height-instance_method" title="Numeric#wilson_height (method)">#wilson_height</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#wilson_height-instance_method" title="Tonal::Ratio#wilson_height (method)">#wilson_height</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -6,7 +6,7 @@
 <title>
   Top Level Namespace
   
-    &mdash; Documentation by YARD 0.9.34
+    &mdash; Documentation by YARD 0.9.36
   
 </title>
 
@@ -102,9 +102,9 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Feb 22 10:13:05 2024 by
+  Generated on Wed Mar 13 21:08:44 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
-  0.9.34 (ruby-3.2.2).
+  0.9.36 (ruby-3.2.2).
 </div>
 
     </div>

--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "2.0.2"
+  TOOLS_VERSION = "3.0.1"
 end

--- a/lib/tonal/cents.rb
+++ b/lib/tonal/cents.rb
@@ -12,7 +12,7 @@ class Tonal::Cents
 
   attr_reader :log, :ratio
 
-  # @return [Cents]
+  # @return [Tonal::Cents]
   # @example
   #   Tonal::Cents.new(ratio: 2**(2.0/12)) => 200.0
   # @param cents [Numeric, Tonal::Log2]
@@ -40,7 +40,7 @@ class Tonal::Cents
     end
   end
 
-  # @return [Cents] the default cents tolerance
+  # @return [Tonal::Cents] the default cents tolerance
   # @example
   #   Tonal::Cents.default_tolerance => 5
   #
@@ -58,7 +58,7 @@ class Tonal::Cents
   alias :cents :value
 
   # @return
-  #   [Cents] nearest hundredth cent value
+  #   [Tonal::Cents] nearest hundredth cent value
   # @example
   #   Tonal::Cents.new(cents: 701.9550008653874).nearest_hundredth => 700.0
   #
@@ -85,7 +85,7 @@ class Tonal::Cents
   end
 
   # @return
-  #   [String] the string representation of Cents
+  #   [String] the string representation of Tonal::Cents
   # @example
   #   Tonal::Cents.new(100.0).inspect => "100.0"
   #

--- a/lib/tonal/extensions.rb
+++ b/lib/tonal/extensions.rb
@@ -86,7 +86,7 @@ class Numeric
   def hz = Tonal::Hertz.new(self)
   alias :to_hz :hz
 
-  # @return [Step] the step of self in the given modulo
+  # @return [Tonal::Step] the step of self in the given modulo
   # @example
   #   (5/4r).step(12) => 4\12
   # @param modulo
@@ -131,7 +131,7 @@ class Numeric
   #
   def efficiency(modulo) = (Tonal::Cents::CENT_SCALE * step(modulo).step / modulo.to_f) - to_cents
 
-  # @return [Interval] beween self (upper) and ratio (lower)
+  # @return [Tonal::Interval] beween self (upper) and ratio (lower)
   # @example
   #   (133).interval_with(3/2r) => 133/96 (133/128 / 3/2)
   # @param ratio

--- a/lib/tonal/hertz.rb
+++ b/lib/tonal/hertz.rb
@@ -3,9 +3,9 @@ class Tonal::Hertz
 
   attr_reader :value
 
-  # @return [Hertz]
+  # @return [Tonal::Hertz]
   # @example
-  #   Hertz.new(1000.0) => 1000.0
+  #   Tonal::Hertz.new(1000.0) => 1000.0
   # @param arg [Numeric, Tonal::Hertz]
   #
   def initialize(arg)
@@ -13,7 +13,7 @@ class Tonal::Hertz
     @value = arg.kind_of?(self.class) ? arg.inspect : arg
   end
 
-  # @return [Hertz] 440 Hz
+  # @return [Tonal::Hertz] 440 Hz
   # @example
   #   Tonal::Hertz.a440 => 440.0
   #
@@ -38,9 +38,9 @@ class Tonal::Hertz
     value.to_f
   end
 
-  # @return [String] the string representation of Hertz
+  # @return [String] the string representation of Tonal::Hertz
   # @example
-  #   Hertz(1000.0).inspect => "1000.0"
+  #   Tonal::Hertz(1000.0).inspect => "1000.0"
   #
   def inspect
     "#{value}"

--- a/lib/tonal/log.rb
+++ b/lib/tonal/log.rb
@@ -53,13 +53,13 @@ class Tonal::Log
   # @return [Tonal::Cents] the cents scale logarithm
   # @example
   #   Tonal::Log.new(logarithmand: 3/2r, base: 2).to_cents => 701.9550008653874
-  # @see Cents
+  # @see Tonal::Cents
   #
   def to_cents(precision: Tonal::Cents::PRECISION)
     Tonal::Cents.new(log: self, precision: precision)
   end
 
-  # @return [Step] the nearest step in the given modulo
+  # @return [Tonal::Step] the nearest step in the given modulo
   # @example
   #   Tonal::Log.new(3/2r, base: 2).step(12) => 7\12
   #

--- a/lib/tonal/reduced_ratio.rb
+++ b/lib/tonal/reduced_ratio.rb
@@ -25,7 +25,7 @@ class Tonal::ReducedRatio < Tonal::Ratio
     Tonal::Ratio.new(antecedent, consequent)
   end
 
-  # @return [Interval] between self (upper) and ratio (lower)
+  # @return [Tonal::Interval] between self (upper) and ratio (lower)
   # @example
   #   Tonal::ReducedRatio.new(133).interval_with(3/2r) => 133/96 (133/128 / 3/2)
   # @param ratio
@@ -33,5 +33,15 @@ class Tonal::ReducedRatio < Tonal::Ratio
   def interval_with(ratio)
     r = ratio.is_a?(self.class) ? ratio : self.class.new(ratio)
     Tonal::Interval.new(self, r)
+  end
+
+  # @return [Tonal::ReducedRatio] with antecedent and precedent switched
+  # @example
+  #   Tonal::ReducedRatio.new(3,2).invert! => (4/3)
+  #
+  def invert!
+    super
+    @antecedent, @consequent = @reduced_antecedent, @reduced_consequent
+    self
   end
 end

--- a/lib/tonal/step.rb
+++ b/lib/tonal/step.rb
@@ -28,16 +28,60 @@ class Tonal::Step
   end
   alias :to_s :inspect
 
+  # @return [Tonal::Step] new step with the ratio mapped to the new modulo
+  # @example
+  #   Tonal::Step.new(ratio: 3/2r, modulo: 31).convert(12)
+  #   => 7\12
+  #
   def convert(new_modulo)
     self.class.new(log: log, modulo: new_modulo)
   end
 
-  def to_r
+  # @return [Rational] of the step
+  # @example
+  #   Tonal::Step.new(ratio: 3/2r, modulo: 31).step_to_r
+  #   => 6735213777669305/4503599627370496
+  #
+  def step_to_r
+    tempered.to_r
+  end
+  alias :to_r :step_to_r
+
+  # @return [Rational] of the ratio
+  # @example
+  #   Tonal::Step.new(ratio: 3/2r, modulo: 31).ratio_to_r
+  #   => 3/2
+  #
+  def ratio_to_r
     ratio.to_r
   end
 
-  def to_cents
+  # @return [Tonal::Cents] measure of step in cents
+  # @example
+  #   Tonal::Step.new(ratio: 3/2r, modulo: 31).step_to_cents
+  #   => 696.77
+  #
+  def step_to_cents
+    tempered.to_cents
+  end
+  alias :to_cents :step_to_cents
+
+  # @return [Tonal::Cents] measure of ratio in cents
+  # @example
+  #   Tonal::Step.new(ratio: 3/2r, modulo: 31).ratio_to_cents
+  #   => 701.96
+  #
+  def ratio_to_cents
     ratio.to_cents
+  end
+
+  # @return [Tonal::Cents] the difference between the step and the ratio
+  # @example
+  #   Tonal::Step.new(ratio: 3/2r, modulo: 31).efficiency
+  #   => 5.19
+  #
+  def efficiency
+    ratio_to_cents - step_to_cents
   end
 
   def +(rhs)

--- a/spec/tonal_tools/ratio_spec.rb
+++ b/spec/tonal_tools/ratio_spec.rb
@@ -232,7 +232,7 @@ RSpec.describe Tonal::Ratio do
     end
 
     describe "#invert" do
-      it "inverts the ratio" do
+      it "returns a new ratio inverted" do
         expect(subject.invert).to eq 2/3r
       end
     end

--- a/spec/tonal_tools/reduced_ratio_spec.rb
+++ b/spec/tonal_tools/reduced_ratio_spec.rb
@@ -12,4 +12,16 @@ RSpec.describe Tonal::ReducedRatio do
       expect(described_class.new(3/2r).interval_with(7/4r)).to eq Tonal::Interval.new(3/2r, 7/4r)
     end
   end
+
+  describe "#invert" do
+    it "returns the inverted reduced ratio" do
+      expect(described_class.new(3/2r).invert).to eq 4/3r
+    end
+  end
+
+  describe "#invert!" do
+    it "returns self inverted" do
+      expect(described_class.new(3/2r).invert!).to eq 4/3r
+    end
+  end
 end

--- a/spec/tonal_tools/step_spec.rb
+++ b/spec/tonal_tools/step_spec.rb
@@ -69,24 +69,44 @@ RSpec.describe Tonal::Step do
     let(:new_modulo) { 13 }
 
     it "creates a new Step with the number mapped on to the new modulo" do
-      expect(subject.convert(new_modulo).step).to eq 8
+      expect(subject.convert(new_modulo)).to eq Tonal::Step.new(ratio: 3/2r, modulo: 13)
     end
   end
 
-  describe "#ratio" do
+  describe "#step_to_r" do
     let(:ratio) { 3/2r }
 
-    it "returns the octave reduced ratio derived from 2^(step/modulo)" do
-      expect(subject.ratio).to eq 3/2r
-    end
+    it("returns the rational of the step") { expect(subject.step_to_r).to eq 6735213777669305/4503599627370496r }
+  end
+
+  describe "#to_r" do
+    let(:ratio) { 3/2r }
+
+    it("returns the rational of the step") { expect(subject.to_r).to eq 6735213777669305/4503599627370496r }
+  end
+
+  describe "#ratio_to_r" do
+    let(:ratio) { 3/2r }
+
+    it("returns the rational of the ratio") { expect(subject.ratio_to_r).to eq 3/2r }
+  end
+
+  describe "#step_to_cents" do
+    let(:ratio) { 3/2r }
+
+    it("returns the cents of the step") { expect(subject.step_to_cents).to eq 696.77 }
   end
 
   describe "#to_cents" do
     let(:ratio) { 3/2r }
 
-    it "returns self converted to cents within 100th accuracy" do
-      expect(subject.to_cents).to eq 701.96
-    end
+    it("returns the cents of the step") { expect(subject.to_cents).to eq 696.77 }
+  end
+
+  describe "#ratio_to_cents" do
+    let(:ratio) { 3/2r }
+
+    it("returns the cents of the ratio") { expect(subject.ratio_to_cents).to eq 701.96 }
   end
 
   describe "#+" do


### PR DESCRIPTION
Disambiguate to_r and to_cents methods in Tonal::Step

The Tonal::Step#to_r and Tonal::Step#to_cents are ambiguous. Are they returning
the values for the step or the values for the ratio from which the step is
derived?

To avoid the ambiguity, this commit adds the Tonal::Step instance method pairs:
step_to_r/ratio_to_r and step_to_cents/ratio_to_cents.

Additionally, this commit:

* Changes Tonal::Step#to_r and Tonal::Step#to_cents to be aliases of step_to_r
  and step_to_cents respectively. This change breaks backward compatibility.

* Adds Tonal::Step#efficiency and changes Tonal::Ratio#efficiency to use it.
  Note, the Tonal::Ratio value is the negative of the Tonal::Step value.

* Fixes a bug in Tonal::ReducedRatio#invert! where the returning instance wasn't
  being reduced after the antecedent and consequent were swapped.