### PR TITLE
Fix interval api

### DIFF
--- a/docs/Array.html
+++ b/docs/Array.html
@@ -1463,7 +1463,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Integer.html
+++ b/docs/Integer.html
@@ -808,7 +808,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Math.html
+++ b/docs/Math.html
@@ -230,7 +230,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Numeric.html
+++ b/docs/Numeric.html
@@ -2561,7 +2561,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Prime.html
+++ b/docs/Prime.html
@@ -253,7 +253,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal.html
+++ b/docs/Tonal.html
@@ -112,7 +112,7 @@
         <dt id="TOOLS_VERSION-constant" class="">TOOLS_VERSION =
           
         </dt>
-        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>3.0.1</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>4.0.1</span><span class='tstring_end'>&quot;</span></span></pre></dd>
       
     </dl>
   
@@ -128,7 +128,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Cents.html
+++ b/docs/Tonal/Cents.html
@@ -1220,7 +1220,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Comma.html
+++ b/docs/Tonal/Comma.html
@@ -504,7 +504,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Hertz.html
+++ b/docs/Tonal/Hertz.html
@@ -822,7 +822,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Interval.html
+++ b/docs/Tonal/Interval.html
@@ -687,7 +687,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Log.html
+++ b/docs/Tonal/Log.html
@@ -1016,7 +1016,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Log2.html
+++ b/docs/Tonal/Log2.html
@@ -216,7 +216,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Ratio.html
+++ b/docs/Tonal/Ratio.html
@@ -6236,7 +6236,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Ratio/Approximation.html
+++ b/docs/Tonal/Ratio/Approximation.html
@@ -1586,7 +1586,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:45 2024 by
+  Generated on Thu Mar 21 18:00:51 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Ratio/Approximation/Set.html
+++ b/docs/Tonal/Ratio/Approximation/Set.html
@@ -413,7 +413,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:45 2024 by
+  Generated on Thu Mar 21 18:00:51 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/ReducedRatio.html
+++ b/docs/Tonal/ReducedRatio.html
@@ -210,7 +210,7 @@
 
   
     <span class="summary_desc"><div class='inline'>
-<p>Between self (upper) and ratio (lower).</p>
+<p>Between ratio (upper) and self (lower).</p>
 </div></span>
   
 </li>
@@ -433,7 +433,7 @@
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns between self (upper) and ratio (lower).</p>
+<p>Returns between ratio (upper) and self (lower).</p>
 
 
   </div>
@@ -444,7 +444,8 @@
     <p class="tag_title">Examples:</p>
     
       
-      <pre class="example code"><code>Tonal::ReducedRatio.new(133).interval_with(3/2r) =&gt; 133/96 (133/128 / 3/2)</code></pre>
+      <pre class="example code"><code>Tonal::ReducedRatio.new(133).interval_with(3/2r)
+=&gt; 192/133 (3/2 / 133/128)</code></pre>
     
   </div>
 <p class="tag_title">Parameters:</p>
@@ -475,7 +476,7 @@
       
         &mdash;
         <div class='inline'>
-<p>between self (upper) and ratio (lower)</p>
+<p>between ratio (upper) and self (lower)</p>
 </div>
       
     </li>
@@ -488,17 +489,17 @@
       <pre class="lines">
 
 
-33
 34
 35
-36</pre>
+36
+37</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/reduced_ratio.rb', line 33</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/reduced_ratio.rb', line 34</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_interval_with'>interval_with</span><span class='lparen'>(</span><span class='id identifier rubyid_ratio'>ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_r'>r</span> <span class='op'>=</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_is_a?'>is_a?</span><span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='rparen'>)</span> <span class='op'>?</span> <span class='id identifier rubyid_ratio'>ratio</span> <span class='op'>:</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_ratio'>ratio</span><span class='rparen'>)</span>
-  <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Interval.html" title="Tonal::Interval (class)">Interval</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Interval.html#initialize-instance_method" title="Tonal::Interval#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='kw'>self</span><span class='comma'>,</span> <span class='id identifier rubyid_r'>r</span><span class='rparen'>)</span>
+  <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Interval.html" title="Tonal::Interval (class)">Interval</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Interval.html#initialize-instance_method" title="Tonal::Interval#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_r'>r</span><span class='comma'>,</span> <span class='kw'>self</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -557,14 +558,14 @@
       <pre class="lines">
 
 
-42
 43
 44
 45
-46</pre>
+46
+47</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/reduced_ratio.rb', line 42</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/reduced_ratio.rb', line 43</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_invert!'>invert!</span>
   <span class='kw'>super</span>
@@ -648,7 +649,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:45 2024 by
+  Generated on Thu Mar 21 18:00:51 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Step.html
+++ b/docs/Tonal/Step.html
@@ -1352,7 +1352,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Vector.html
+++ b/docs/Vector.html
@@ -242,7 +242,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -295,7 +295,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -79,7 +79,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,7 +79,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -102,7 +102,7 @@
 </div>
 
       <div id="footer">
-  Generated on Wed Mar 13 21:08:44 2024 by
+  Generated on Thu Mar 21 18:00:50 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "3.0.1"
+  TOOLS_VERSION = "4.0.1"
 end

--- a/lib/tonal/reduced_ratio.rb
+++ b/lib/tonal/reduced_ratio.rb
@@ -25,14 +25,15 @@ class Tonal::ReducedRatio < Tonal::Ratio
     Tonal::Ratio.new(antecedent, consequent)
   end
 
-  # @return [Tonal::Interval] between self (upper) and ratio (lower)
+  # @return [Tonal::Interval] between ratio (upper) and self (lower)
   # @example
-  #   Tonal::ReducedRatio.new(133).interval_with(3/2r) => 133/96 (133/128 / 3/2)
+  #   Tonal::ReducedRatio.new(133).interval_with(3/2r)
+  #   => 192/133 (3/2 / 133/128)
   # @param ratio
   #
   def interval_with(ratio)
     r = ratio.is_a?(self.class) ? ratio : self.class.new(ratio)
-    Tonal::Interval.new(self, r)
+    Tonal::Interval.new(r, self)
   end
 
   # @return [Tonal::ReducedRatio] with antecedent and precedent switched

--- a/spec/tonal_tools/interval_spec.rb
+++ b/spec/tonal_tools/interval_spec.rb
@@ -6,90 +6,90 @@ RSpec.describe Tonal::Interval do
     let(:upper_ratio) { [7/4r, Tonal::ReducedRatio.new(7,4), Tonal::Ratio.new(7, 1)].sample }
 
     it "accepts a Rational, Tonal::Ratio or Tonal::ReducedRatio as upper and lower ratios" do
-      expect(described_class.new(lower_ratio, upper_ratio)).to be_a_kind_of(Tonal::Interval)
+      expect(described_class.new(upper_ratio, lower_ratio)).to be_a_kind_of(Tonal::Interval)
     end
 
     describe "order of inputs" do
-      context "when lower ratio is greater than the upper ratio" do
-        let(:lower_ratio) { 7/4r }
-        let(:upper_ratio) { 5/4r }
+      context "when upper ratio is greater than the lower ratio" do
+        let(:upper_ratio) { 7/4r }
+        let(:lower_ratio) { 5/4r }
 
-        it "returns the equave reduced interval between the lower ratio and the upper ratio" do
-          expect(described_class.new(lower_ratio, upper_ratio).interval).to eq 7/5r
+        it "returns the interval between the upper ratio and the lower ratio" do
+          expect(described_class.new(upper_ratio, lower_ratio).interval).to eq 7/5r
         end
       end
 
-      context "when upper ratio is greater than the lower ratio" do
-        let(:lower_ratio) { 5/4r }
-        let(:upper_ratio) { 7/4r }
+      context "when lower ratio is greater than the upper ratio" do
+        let(:upper_ratio) { 5/4r }
+        let(:lower_ratio) { 7/4r }
 
         it "returns the interval between the lower ratio and the upper ratio" do
-          expect(described_class.new(lower_ratio, upper_ratio).interval).to eq 10/7r
+          expect(described_class.new(upper_ratio, lower_ratio).interval).to eq 10/7r
         end
       end
     end
   end
 
   describe "attributes" do
-    let(:lower_ratio) { 3/2r }
-    let(:upper_ratio) { 7/4r }
+    let(:upper_ratio) { 3/2r }
+    let(:lower_ratio) { 7/4r }
 
     describe "#interval" do
       it "returns the interval calculated from upper and lower ratios" do
-        expect(described_class.new(lower_ratio, upper_ratio).interval).to eq 12/7r
+        expect(described_class.new(upper_ratio, lower_ratio).interval).to eq 12/7r
       end
     end
 
     describe "#numerator/#denominator" do
       it "returns the numerator and denominator of the interval" do
-        expect(described_class.new(lower_ratio, upper_ratio).numerator).to eq 12
-        expect(described_class.new(lower_ratio, upper_ratio).denominator).to eq 7
+        expect(described_class.new(upper_ratio, lower_ratio).numerator).to eq 12
+        expect(described_class.new(upper_ratio, lower_ratio).denominator).to eq 7
       end
     end
 
     describe "ratios" do
       it "returns the upper and lower ratios" do
-        expect(described_class.new(lower_ratio, upper_ratio).lower).to eq 7/4r
-        expect(described_class.new(lower_ratio, upper_ratio).upper).to eq 3/2r
+        expect(described_class.new(upper_ratio, lower_ratio).lower).to eq 7/4r
+        expect(described_class.new(upper_ratio, lower_ratio).upper).to eq 3/2r
       end
     end
   end
 
   describe "#denominize" do
-    let(:lower_ratio) { 3/2r }
-    let(:upper_ratio) { 7/4r }
+    let(:upper_ratio) { 3/2r }
+    let(:lower_ratio) { 7/4r }
 
     it "returns the interval endpoints with their denominators equalized" do
-      expect(described_class.new(lower_ratio, upper_ratio).denominize).to eq [7/4r, 6/4r]
+      expect(described_class.new(upper_ratio, lower_ratio).denominize).to eq [7/4r, 6/4r]
     end
   end
 
   describe "#ratio" do
-    let(:lower_ratio) { 3/2r }
-    let(:upper_ratio) { 7/4r }
+    let(:upper_ratio) { 3/2r }
+    let(:lower_ratio) { 7/4r }
 
     it "returns the interval as a Tonal::ReducedRatio" do
-      expect(described_class.new(lower_ratio, upper_ratio).ratio).to be_a_kind_of(Tonal::ReducedRatio)
-      expect(described_class.new(lower_ratio, upper_ratio).ratio).to eq 12/7r
+      expect(described_class.new(upper_ratio, lower_ratio).ratio).to be_a_kind_of(Tonal::ReducedRatio)
+      expect(described_class.new(upper_ratio, lower_ratio).ratio).to eq 12/7r
     end
   end
 
   describe "#to_r" do
-    let(:lower_ratio) { 27/16r }
-    let(:upper_ratio) { 35/18r }
+    let(:upper_ratio) { 27/16r }
+    let(:lower_ratio) { 35/18r }
 
     it "returns the interval ratio as a Rational" do
-      expect(described_class.new(lower_ratio, upper_ratio).to_r).to be_a_kind_of(Rational)
-      expect(described_class.new(lower_ratio, upper_ratio).to_r).to eq 243/140r
+      expect(described_class.new(upper_ratio, lower_ratio).to_r).to be_a_kind_of(Rational)
+      expect(described_class.new(upper_ratio, lower_ratio).to_r).to eq 243/140r
     end
   end
 
   describe "#to_a" do
-    let(:lower_ratio) { 3/2r }
-    let(:upper_ratio) { 7/4r }
+    let(:upper_ratio) { 3/2r }
+    let(:lower_ratio) { 7/4r }
 
     it "returns the interval endpoints in an array" do
-      expect(described_class.new(lower_ratio, upper_ratio).to_a).to eq [7/4r, 3/2r]
+      expect(described_class.new(upper_ratio, lower_ratio).to_a).to eq [7/4r, 3/2r]
     end
   end
 end

--- a/spec/tonal_tools/reduced_ratio_spec.rb
+++ b/spec/tonal_tools/reduced_ratio_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Tonal::ReducedRatio do
   end
 
   describe "#interval_with" do
-    it "returns the interval between self and the given ratio" do
-      expect(described_class.new(3/2r).interval_with(7/4r)).to eq Tonal::Interval.new(3/2r, 7/4r)
+    it "returns the interval between self (lower) and the given ratio (upper)" do
+      expect(described_class.new(3/2r).interval_with(7/4r)).to eq Tonal::Interval.new(7/4r, 3/2r)
     end
   end
 


### PR DESCRIPTION
The upper/lower arguments to Tonal::Interval were not being applied consistently
everywhere. The upper ratio used in the computation should be the first argument
to the method, the lower ratio is the second argument.
    
This change makes the upper/lower arguments passed to Tonal::Interval consistent
in tests and in the call made from Tonal::ReducedRatio.