### PR TITLE
Add to_a alias to Tonal::Cents

### DIFF
--- a/data/commas.yml
+++ b/data/commas.yml
@@ -1,11 +1,13 @@
 commas:
-  # Interval between two enharmonically equivalent notes, as B# and C, in the Pythogorean tuning. ~23 cents
-  ditonic: 531441/524288
-  # The interval between a just major third (5:4) and a Pythogorean third (81:64). ~22 cents
-  syntonic: 81/80
-  # Difference between the syntonic and ditonic commas. ~2 cents
-  schisma: 32805/32768
   diaschisma: 2048/2025
+  # Interval between 16/15 and 10/9, 27/25 and 9/8, 6/5 and 5/4, 8/5 and 5/3, 16/9 and 50/27, 9/5 and 15/8. ~71¢
+  dicot: 25/24
   dieses1: 648/625
   dieses2: 128/125
+  # Interval between two enharmonically equivalent notes, as B# and C, in the Pythogorean tuning. ~23¢
+  ditonic: 531441/524288
+  # Difference between the syntonic and ditonic commas. ~2¢
+  schisma: 32805/32768
   septimal: 64/63
+  # The interval between a just major third (5:4) and a Pythogorean third (81:64). ~22¢
+  syntonic: 81/80

--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "5.1.1"
+  TOOLS_VERSION = "5.1.2"
 end

--- a/lib/tonal/cents.rb
+++ b/lib/tonal/cents.rb
@@ -93,6 +93,7 @@ class Tonal::Cents
   def inspect
     "#{value.round(@precision)}"
   end
+  alias :to_s :inspect
 
   #
   # Challenges to comparing floats

--- a/lib/tonal/comma.rb
+++ b/lib/tonal/comma.rb
@@ -2,9 +2,9 @@ class Tonal::Comma
   # @return [Hash] of comma key/value pairs
   # @example
   #   Tonal::Comma.commas
-  #   => {"ditonic"=>"531441/524288",
-  #       "syntonic"=>"81/80",
-  #       "schisma"=>"32805/32768",
+  #   => {"diaschisma"=>"2048/2025",
+  #       "dicot"=>"25/24",
+  #       "dieses1"=>"648/625",
   #       ...}
   #
   def self.commas
@@ -14,10 +14,7 @@ class Tonal::Comma
   # @return [Array] of comma values
   # @example
   #   Tonal::Comma.values
-  #   => [(531441/524288),
-  #       (81/80),
-  #       (32805/32768),
-  #       ...]
+  #   => [(2048/2025), (25/24), (648/625), ...]
   #
   def self.values
     @values ||= commas.values.map(&:to_r)
@@ -26,10 +23,7 @@ class Tonal::Comma
   # @return [Array] of comma keys
   # @example
   #   Tonal::Comma.keys
-  #   => ["ditonic",
-  #       "syntonic",
-  #       "schisma",
-  #       ...]
+  #   => ["diaschisma", "dicot", "dieses1", ...]
   #
   def self.keys
     @keys ||= commas.keys

--- a/spec/tonal_tools/comma_spec.rb
+++ b/spec/tonal_tools/comma_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Tonal::Comma do
 
     describe ".values" do
       it "returns values from the repo" do
-        expect(described_class.values).to start_with(531441/524288r)
+        expect(described_class.values).to start_with(2048/2025r)
       end
     end
 
     describe ".keys" do
       it "returns keys from the repo" do
-        expect(described_class.keys).to start_with("ditonic")
+        expect(described_class.keys).to start_with("diaschisma")
       end
     end
   end


### PR DESCRIPTION
Tonal::Cents#to_s was outputting class instance information (e.g. Tonal::Cents:0x00000001054a5d20). We want to_s to produce the same output as the inspect method.

This change aliases Tonal::Cents#to_s to Tonal::Cents#inspect.

It also alphabetizes the Comma entries in the source data YAML file, for easier scanning of the files contents.