### PR TITLE
Update to use fraction-tree 2

### DIFF
--- a/docs/Array.html
+++ b/docs/Array.html
@@ -910,6 +910,28 @@
       <pre class="example code"><code>[[[3, 1]], [[2, 1]]].ratio_from_prime_divisions =&gt; (3/2)</code></pre>
     
   </div>
+<p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>reduced</span>
+      
+      
+        <span class='type'>(<tt>Boolean</tt>)</span>
+      
+      
+        <em class="default">(defaults to: <tt>false</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>if a reduced or unreduced ratio is returned</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 <p class="tag_title">Returns:</p>
 <ul class="return">
@@ -1463,7 +1485,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:25 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Integer.html
+++ b/docs/Integer.html
@@ -808,7 +808,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:25 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Math.html
+++ b/docs/Math.html
@@ -230,7 +230,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Numeric.html
+++ b/docs/Numeric.html
@@ -924,7 +924,7 @@
   
     <li>
       
-        <span class='name'></span>
+        <span class='name'>factor</span>
       
       
         <span class='type'>(<tt><span class='object_link'><a href="" title="Numeric (class)">Numeric</a></span></tt>)</span>
@@ -2561,7 +2561,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Prime.html
+++ b/docs/Prime.html
@@ -253,7 +253,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal.html
+++ b/docs/Tonal.html
@@ -112,7 +112,7 @@
         <dt id="TOOLS_VERSION-constant" class="">TOOLS_VERSION =
           
         </dt>
-        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>5.1.1</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>5.1.3</span><span class='tstring_end'>&quot;</span></span></pre></dd>
       
     </dl>
   
@@ -128,7 +128,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Cents.html
+++ b/docs/Tonal/Cents.html
@@ -311,6 +311,8 @@
     
 
     
+      (also: #to_s)
+    
   </span>
   
   
@@ -622,7 +624,6 @@
       <pre class="lines">
 
 
-130
 131
 132
 133
@@ -634,10 +635,11 @@
 139
 140
 141
-142</pre>
+142
+143</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/cents.rb', line 130</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/cents.rb', line 131</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_method_missing'>method_missing</span><span class='lparen'>(</span><span class='id identifier rubyid_op'>op</span><span class='comma'>,</span> <span class='op'>*</span><span class='id identifier rubyid_args'>args</span><span class='comma'>,</span> <span class='op'>&amp;</span><span class='id identifier rubyid_blk'>blk</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_rhs'>rhs</span> <span class='op'>=</span> <span class='id identifier rubyid_args'>args</span><span class='period'>.</span><span class='id identifier rubyid_collect'>collect</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_arg'>arg</span><span class='op'>|</span>
@@ -854,12 +856,12 @@
       <pre class="lines">
 
 
-102
 103
-104</pre>
+104
+105</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/cents.rb', line 102</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/cents.rb', line 103</span>
 
 <span class='kw'>def</span> <span class='op'>&lt;=&gt;</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_kind_of?'>kind_of?</span><span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='rparen'>)</span> <span class='op'>?</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Cents::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span> <span class='op'>&lt;=&gt;</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Cents::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span> <span class='op'>:</span> <span class='id identifier rubyid_value'>value</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Cents::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span> <span class='op'>&lt;=&gt;</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Cents::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
@@ -875,6 +877,10 @@
     #<strong>inspect</strong>  &#x21d2; <tt>Object</tt> 
   
 
+  
+    <span class="aliases">Also known as:
+    <span class="names"><span id='to_s-instance_method'>to_s</span></span>
+    </span>
   
 
   
@@ -1220,7 +1226,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Comma.html
+++ b/docs/Tonal/Comma.html
@@ -243,9 +243,9 @@
     
       
       <pre class="example code"><code>Tonal::Comma.commas
-=&gt; {&quot;ditonic&quot;=&gt;&quot;531441/524288&quot;,
-    &quot;syntonic&quot;=&gt;&quot;81/80&quot;,
-    &quot;schisma&quot;=&gt;&quot;32805/32768&quot;,
+=&gt; {&quot;diaschisma&quot;=&gt;&quot;2048/2025&quot;,
+    &quot;dicot&quot;=&gt;&quot;25/24&quot;,
+    &quot;dieses1&quot;=&gt;&quot;648/625&quot;,
     ...}</code></pre>
     
   </div>
@@ -314,10 +314,7 @@
     
       
       <pre class="example code"><code>Tonal::Comma.keys
-=&gt; [&quot;ditonic&quot;,
-    &quot;syntonic&quot;,
-    &quot;schisma&quot;,
-    ...]</code></pre>
+=&gt; [&quot;diaschisma&quot;, &quot;dicot&quot;, &quot;dieses1&quot;, ...]</code></pre>
     
   </div>
 
@@ -346,12 +343,12 @@
       <pre class="lines">
 
 
-34
-35
-36</pre>
+28
+29
+30</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/comma.rb', line 34</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/comma.rb', line 28</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_keys'>keys</span>
   <span class='ivar'>@keys</span> <span class='op'>||=</span> <span class='id identifier rubyid_commas'>commas</span><span class='period'>.</span><span class='id identifier rubyid_keys'>keys</span>
@@ -413,12 +410,12 @@
       <pre class="lines">
 
 
-42
-43
-44</pre>
+36
+37
+38</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/comma.rb', line 42</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/comma.rb', line 36</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_method_missing'>method_missing</span><span class='lparen'>(</span><span class='id identifier rubyid_comma'>comma</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_commas'>commas</span><span class='lbracket'>[</span><span class='id identifier rubyid_comma'>comma</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_to_r'>to_r</span>
@@ -452,10 +449,7 @@
     
       
       <pre class="example code"><code>Tonal::Comma.values
-=&gt; [(531441/524288),
-    (81/80),
-    (32805/32768),
-    ...]</code></pre>
+=&gt; [(2048/2025), (25/24), (648/625), ...]</code></pre>
     
   </div>
 
@@ -484,12 +478,12 @@
       <pre class="lines">
 
 
-22
-23
-24</pre>
+19
+20
+21</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/comma.rb', line 22</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/comma.rb', line 19</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span>
   <span class='ivar'>@values</span> <span class='op'>||=</span> <span class='id identifier rubyid_commas'>commas</span><span class='period'>.</span><span class='id identifier rubyid_values'>values</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:to_r</span><span class='rparen'>)</span>
@@ -504,7 +498,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Hertz.html
+++ b/docs/Tonal/Hertz.html
@@ -822,7 +822,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Interval.html
+++ b/docs/Tonal/Interval.html
@@ -687,7 +687,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Log.html
+++ b/docs/Tonal/Log.html
@@ -1016,7 +1016,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Log2.html
+++ b/docs/Tonal/Log2.html
@@ -216,7 +216,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Ratio.html
+++ b/docs/Tonal/Ratio.html
@@ -6236,7 +6236,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Ratio/Approximation.html
+++ b/docs/Tonal/Ratio/Approximation.html
@@ -303,30 +303,6 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#by_quotient_walk-instance_method" title="#by_quotient_walk (instance method)">#<strong>by_quotient_walk</strong>(cents_tolerance: Tonal::Cents::TOLERANCE, depth: DEFAULT_FRACTION_TREE_DEPTH, max_prime: DEFAULT_MAX_PRIME, conv_limit: CONVERGENT_LIMIT)  &#x21d2; Tonal::Ratio::Approximation::Set </a>
-    
-
-    
-  </span>
-  
-  
-  
-  
-  
-  
-  
-
-  
-    <span class="summary_desc"><div class='inline'>
-<p>Of ratios within cent tolerance of self found using a quotient walk on the fraction tree.</p>
-</div></span>
-  
-</li>
-
-      
-        <li class="public ">
-  <span class="summary_signature">
-    
       <a href="#by_superparticular-instance_method" title="#by_superparticular (instance method)">#<strong>by_superparticular</strong>(cents_tolerance: Tonal::Cents::TOLERANCE, depth: DEFAULT_SUPERPART_DEPTH, max_prime: DEFAULT_MAX_PRIME, superpart: :upper)  &#x21d2; Tonal::Ratio::Approximation::Set </a>
     
 
@@ -615,20 +591,20 @@
       <pre class="lines">
 
 
-163
-164
-165
-166
-167
-168
-169
-170
-171
-172
-173</pre>
+141
+142
+143
+144
+145
+146
+147
+148
+149
+150
+151</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 163</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 141</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_neighbors'>neighbors</span><span class='lparen'>(</span><span class='label'>vacinity:</span><span class='comma'>,</span> <span class='label'>away:</span> <span class='int'>1</span><span class='rparen'>)</span>
   <span class='lbracket'>[</span><span class='id identifier rubyid_vacinity'>vacinity</span><span class='comma'>,</span>
@@ -959,29 +935,29 @@
       <pre class="lines">
 
 
-119
-120
-121
-122
-123
-124
-125
-126
-127
-128
-129
-130
-131
-132
-133
-134
-135
-136
-137
-138</pre>
+97
+98
+99
+100
+101
+102
+103
+104
+105
+106
+107
+108
+109
+110
+111
+112
+113
+114
+115
+116</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 119</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 97</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_by_neighborhood'>by_neighborhood</span><span class='lparen'>(</span><span class='label'>cents_tolerance:</span> <span class='const'><span class='object_link'><a href="../../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html#TOLERANCE-constant" title="Tonal::Cents::TOLERANCE (constant)">TOLERANCE</a></span></span><span class='comma'>,</span> <span class='label'>depth:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_NEIGHBORHOOD_DEPTH-constant" title="Tonal::Ratio::Approximation::DEFAULT_NEIGHBORHOOD_DEPTH (constant)">DEFAULT_NEIGHBORHOOD_DEPTH</a></span></span><span class='comma'>,</span> <span class='label'>max_prime:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_MAX_PRIME-constant" title="Tonal::Ratio::Approximation::DEFAULT_MAX_PRIME (constant)">DEFAULT_MAX_PRIME</a></span></span><span class='comma'>,</span> <span class='label'>max_boundary:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_MAX_GRID_BOUNDARY-constant" title="Tonal::Ratio::Approximation::DEFAULT_MAX_GRID_BOUNDARY (constant)">DEFAULT_MAX_GRID_BOUNDARY</a></span></span><span class='comma'>,</span> <span class='label'>max_scale:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_MAX_GRID_SCALE-constant" title="Tonal::Ratio::Approximation::DEFAULT_MAX_GRID_SCALE (constant)">DEFAULT_MAX_GRID_SCALE</a></span></span><span class='rparen'>)</span>
   <span class='id identifier rubyid_self_in_cents'>self_in_cents</span> <span class='op'>=</span> <span class='id identifier rubyid_to_cents'>to_cents</span>
@@ -1000,168 +976,6 @@
       <span class='kw'>end</span>
       <span class='id identifier rubyid_boundary'>boundary</span> <span class='op'>=</span> <span class='int'>1</span>
       <span class='id identifier rubyid_scale'>scale</span> <span class='op'>+=</span> <span class='int'>1</span>
-    <span class='kw'>end</span>
-  <span class='kw'>end</span>
-<span class='kw'>end</span></pre>
-    </td>
-  </tr>
-</table>
-</div>
-    
-      <div class="method_details ">
-  <h3 class="signature " id="by_quotient_walk-instance_method">
-  
-    #<strong>by_quotient_walk</strong>(cents_tolerance: Tonal::Cents::TOLERANCE, depth: DEFAULT_FRACTION_TREE_DEPTH, max_prime: DEFAULT_MAX_PRIME, conv_limit: CONVERGENT_LIMIT)  &#x21d2; <tt><span class='object_link'><a href="Approximation/Set.html" title="Tonal::Ratio::Approximation::Set (class)">Tonal::Ratio::Approximation::Set</a></span></tt> 
-  
-
-  
-
-  
-</h3><div class="docstring">
-  <div class="discussion">
-    
-<p>Returns of ratios within cent tolerance of self found using a quotient walk on the fraction tree.</p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-  <div class="examples">
-    <p class="tag_title">Examples:</p>
-    
-      
-      <pre class="example code"><code>Tonal::Ratio.ed(12,1).approximate.by_quotient_walk(max_prime: 89)
-=&gt; (4771397596969315/4503599627370496): [(17/16), (18/17), (35/33), (53/50), (71/67), (89/84), (196/185)]</code></pre>
-    
-  </div>
-<p class="tag_title">Parameters:</p>
-<ul class="param">
-  
-    <li>
-      
-        <span class='name'>cents_tolerance</span>
-      
-      
-        <span class='type'></span>
-      
-      
-        <em class="default">(defaults to: <tt>Tonal::Cents::TOLERANCE</tt>)</em>
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>the cents tolerance used to scope the collection</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>depth</span>
-      
-      
-        <span class='type'></span>
-      
-      
-        <em class="default">(defaults to: <tt>DEFAULT_FRACTION_TREE_DEPTH</tt>)</em>
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>the maximum number of ratios in the collection</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>max_prime</span>
-      
-      
-        <span class='type'></span>
-      
-      
-        <em class="default">(defaults to: <tt>DEFAULT_MAX_PRIME</tt>)</em>
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>the maximum prime number to allow in the collection</p>
-</div>
-      
-    </li>
-  
-    <li>
-      
-        <span class='name'>conv_limit</span>
-      
-      
-        <span class='type'></span>
-      
-      
-        <em class="default">(defaults to: <tt>CONVERGENT_LIMIT</tt>)</em>
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>the number of convergents to limit the ContinuedFraction method</p>
-</div>
-      
-    </li>
-  
-</ul>
-
-<p class="tag_title">Returns:</p>
-<ul class="return">
-  
-    <li>
-      
-      
-        <span class='type'>(<tt><span class='object_link'><a href="Approximation/Set.html" title="Tonal::Ratio::Approximation::Set (class)">Tonal::Ratio::Approximation::Set</a></span></tt>)</span>
-      
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>of ratios within cent tolerance of self found using a quotient walk on the fraction tree</p>
-</div>
-      
-    </li>
-  
-</ul>
-
-</div><table class="source_code">
-  <tr>
-    <td>
-      <pre class="lines">
-
-
-53
-54
-55
-56
-57
-58
-59
-60
-61
-62
-63
-64</pre>
-    </td>
-    <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 53</span>
-
-<span class='kw'>def</span> <span class='id identifier rubyid_by_quotient_walk'>by_quotient_walk</span><span class='lparen'>(</span><span class='label'>cents_tolerance:</span> <span class='const'><span class='object_link'><a href="../../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html#TOLERANCE-constant" title="Tonal::Cents::TOLERANCE (constant)">TOLERANCE</a></span></span><span class='comma'>,</span> <span class='label'>depth:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_FRACTION_TREE_DEPTH-constant" title="Tonal::Ratio::Approximation::DEFAULT_FRACTION_TREE_DEPTH (constant)">DEFAULT_FRACTION_TREE_DEPTH</a></span></span><span class='comma'>,</span> <span class='label'>max_prime:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_MAX_PRIME-constant" title="Tonal::Ratio::Approximation::DEFAULT_MAX_PRIME (constant)">DEFAULT_MAX_PRIME</a></span></span><span class='comma'>,</span> <span class='label'>conv_limit:</span> <span class='const'><span class='object_link'><a href="#CONVERGENT_LIMIT-constant" title="Tonal::Ratio::Approximation::CONVERGENT_LIMIT (constant)">CONVERGENT_LIMIT</a></span></span><span class='rparen'>)</span>
-  <span class='id identifier rubyid_self_in_cents'>self_in_cents</span> <span class='op'>=</span> <span class='id identifier rubyid_to_cents'>to_cents</span>
-  <span class='id identifier rubyid_within'>within</span> <span class='op'>=</span> <span class='id identifier rubyid_cents_tolerance'>cents_tolerance</span><span class='period'>.</span><span class='id identifier rubyid_kind_of?'>kind_of?</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='rparen'>)</span> <span class='op'>?</span> <span class='id identifier rubyid_cents_tolerance'>cents_tolerance</span> <span class='op'>:</span> <span class='const'><span class='object_link'><a href="../../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="../Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>cents:</span> <span class='id identifier rubyid_cents_tolerance'>cents_tolerance</span><span class='rparen'>)</span>
-
-  <span class='const'><span class='object_link'><a href="Approximation/Set.html" title="Tonal::Ratio::Approximation::Set (class)">Set</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Approximation/Set.html#initialize-instance_method" title="Tonal::Ratio::Approximation::Set#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_ratios'>ratios</span><span class='op'>|</span>
-    <span class='const'>FractionTree</span><span class='period'>.</span><span class='id identifier rubyid_quotient_walk'>quotient_walk</span><span class='lparen'>(</span><span class='id identifier rubyid_to_f'>to_f</span><span class='comma'>,</span> <span class='label'>limit:</span> <span class='id identifier rubyid_conv_limit'>conv_limit</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_each'>each</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_node'>node</span><span class='op'>|</span>
-      <span class='id identifier rubyid_ratio2'>ratio2</span> <span class='op'>=</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_node'>node</span><span class='period'>.</span><span class='id identifier rubyid_weight'>weight</span><span class='rparen'>)</span>
-      <span class='id identifier rubyid_ratios'>ratios</span> <span class='op'>&lt;&lt;</span> <span class='id identifier rubyid_ratio2'>ratio2</span> <span class='kw'>if</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_within_cents?'>within_cents?</span><span class='lparen'>(</span><span class='id identifier rubyid_self_in_cents'>self_in_cents</span><span class='comma'>,</span> <span class='id identifier rubyid_ratio2'>ratio2</span><span class='period'>.</span><span class='id identifier rubyid_to_cents'>to_cents</span><span class='comma'>,</span> <span class='id identifier rubyid_within'>within</span><span class='rparen'>)</span> <span class='op'>&amp;&amp;</span> <span class='id identifier rubyid_ratio2'>ratio2</span><span class='period'>.</span><span class='id identifier rubyid_within_prime?'>within_prime?</span><span class='lparen'>(</span><span class='id identifier rubyid_max_prime'>max_prime</span><span class='rparen'>)</span>
-      <span class='kw'>break</span> <span class='kw'>if</span> <span class='id identifier rubyid_ratios'>ratios</span><span class='period'>.</span><span class='id identifier rubyid_length'>length</span> <span class='op'>&gt;=</span> <span class='id identifier rubyid_depth'>depth</span>
     <span class='kw'>end</span>
   <span class='kw'>end</span>
 <span class='kw'>end</span></pre>
@@ -1299,22 +1113,22 @@
       <pre class="lines">
 
 
-95
-96
-97
-98
-99
-100
-101
-102
-103
-104
-105
-106
-107</pre>
+73
+74
+75
+76
+77
+78
+79
+80
+81
+82
+83
+84
+85</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 95</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 73</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_by_superparticular'>by_superparticular</span><span class='lparen'>(</span><span class='label'>cents_tolerance:</span> <span class='const'><span class='object_link'><a href="../../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html#TOLERANCE-constant" title="Tonal::Cents::TOLERANCE (constant)">TOLERANCE</a></span></span><span class='comma'>,</span> <span class='label'>depth:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_SUPERPART_DEPTH-constant" title="Tonal::Ratio::Approximation::DEFAULT_SUPERPART_DEPTH (constant)">DEFAULT_SUPERPART_DEPTH</a></span></span><span class='comma'>,</span> <span class='label'>max_prime:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_MAX_PRIME-constant" title="Tonal::Ratio::Approximation::DEFAULT_MAX_PRIME (constant)">DEFAULT_MAX_PRIME</a></span></span><span class='comma'>,</span> <span class='label'>superpart:</span> <span class='symbol'>:upper</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_self_in_cents'>self_in_cents</span> <span class='op'>=</span> <span class='id identifier rubyid_to_cents'>to_cents</span>
@@ -1445,27 +1259,27 @@
       <pre class="lines">
 
 
-74
-75
-76
-77
-78
-79
-80
-81
-82
-83
-84</pre>
+52
+53
+54
+55
+56
+57
+58
+59
+60
+61
+62</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 74</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 52</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_by_tree_path'>by_tree_path</span><span class='lparen'>(</span><span class='label'>cents_tolerance:</span> <span class='const'><span class='object_link'><a href="../../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html#TOLERANCE-constant" title="Tonal::Cents::TOLERANCE (constant)">TOLERANCE</a></span></span><span class='comma'>,</span> <span class='label'>depth:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_FRACTION_TREE_DEPTH-constant" title="Tonal::Ratio::Approximation::DEFAULT_FRACTION_TREE_DEPTH (constant)">DEFAULT_FRACTION_TREE_DEPTH</a></span></span><span class='comma'>,</span> <span class='label'>max_prime:</span> <span class='const'><span class='object_link'><a href="#DEFAULT_MAX_PRIME-constant" title="Tonal::Ratio::Approximation::DEFAULT_MAX_PRIME (constant)">DEFAULT_MAX_PRIME</a></span></span><span class='rparen'>)</span>
   <span class='id identifier rubyid_self_in_cents'>self_in_cents</span> <span class='op'>=</span> <span class='id identifier rubyid_to_cents'>to_cents</span>
   <span class='id identifier rubyid_within'>within</span> <span class='op'>=</span> <span class='id identifier rubyid_cents_tolerance'>cents_tolerance</span><span class='period'>.</span><span class='id identifier rubyid_kind_of?'>kind_of?</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='rparen'>)</span> <span class='op'>?</span> <span class='id identifier rubyid_cents_tolerance'>cents_tolerance</span> <span class='op'>:</span> <span class='const'><span class='object_link'><a href="../../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="../Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="../Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>cents:</span> <span class='id identifier rubyid_cents_tolerance'>cents_tolerance</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="Approximation/Set.html" title="Tonal::Ratio::Approximation::Set (class)">Set</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Approximation/Set.html#initialize-instance_method" title="Tonal::Ratio::Approximation::Set#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_ratios'>ratios</span><span class='op'>|</span>
-    <span class='const'>FractionTree</span><span class='period'>.</span><span class='id identifier rubyid_path_to'>path_to</span><span class='lparen'>(</span><span class='id identifier rubyid_to_f'>to_f</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_each'>each</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_node'>node</span><span class='op'>|</span>
-      <span class='id identifier rubyid_ratio2'>ratio2</span> <span class='op'>=</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_node'>node</span><span class='period'>.</span><span class='id identifier rubyid_weight'>weight</span><span class='rparen'>)</span>
+    <span class='const'>FractionTree</span><span class='period'>.</span><span class='id identifier rubyid_node'>node</span><span class='lparen'>(</span><span class='id identifier rubyid_to_f'>to_f</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_path'>path</span><span class='period'>.</span><span class='id identifier rubyid_each'>each</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_node'>node</span><span class='op'>|</span>
+      <span class='id identifier rubyid_ratio2'>ratio2</span> <span class='op'>=</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_node'>node</span><span class='period'>.</span><span class='id identifier rubyid_number'>number</span><span class='rparen'>)</span>
       <span class='id identifier rubyid_ratios'>ratios</span> <span class='op'>&lt;&lt;</span> <span class='id identifier rubyid_ratio2'>ratio2</span> <span class='kw'>if</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_within_cents?'>within_cents?</span><span class='lparen'>(</span><span class='id identifier rubyid_self_in_cents'>self_in_cents</span><span class='comma'>,</span> <span class='id identifier rubyid_ratio2'>ratio2</span><span class='period'>.</span><span class='id identifier rubyid_to_cents'>to_cents</span><span class='comma'>,</span> <span class='id identifier rubyid_within'>within</span><span class='rparen'>)</span> <span class='op'>&amp;&amp;</span> <span class='id identifier rubyid_ratio2'>ratio2</span><span class='period'>.</span><span class='id identifier rubyid_within_prime?'>within_prime?</span><span class='lparen'>(</span><span class='id identifier rubyid_max_prime'>max_prime</span><span class='rparen'>)</span>
       <span class='kw'>break</span> <span class='kw'>if</span> <span class='id identifier rubyid_ratios'>ratios</span><span class='period'>.</span><span class='id identifier rubyid_length'>length</span> <span class='op'>&gt;=</span> <span class='id identifier rubyid_depth'>depth</span>
     <span class='kw'>end</span>
@@ -1569,18 +1383,18 @@
       <pre class="lines">
 
 
-147
-148
-149
-150
-151
-152
-153
-154
-155</pre>
+125
+126
+127
+128
+129
+130
+131
+132
+133</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 147</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 125</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_neighborhood'>neighborhood</span><span class='lparen'>(</span><span class='label'>scale:</span> <span class='int'>2</span><span class='op'>**</span><span class='int'>0</span><span class='comma'>,</span> <span class='label'>boundary:</span> <span class='int'>1</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_scale'>scale</span> <span class='op'>=</span> <span class='id identifier rubyid_scale'>scale</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span>
@@ -1601,7 +1415,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:25 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Ratio/Approximation/Set.html
+++ b/docs/Tonal/Ratio/Approximation/Set.html
@@ -298,14 +298,14 @@
       <pre class="lines">
 
 
-181
-182
-183
-184
-185</pre>
+159
+160
+161
+162
+163</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 181</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 159</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>ratio:</span><span class='rparen'>)</span>
   <span class='ivar'>@ratio</span> <span class='op'>=</span> <span class='id identifier rubyid_ratio'>ratio</span>
@@ -350,12 +350,12 @@
       <pre class="lines">
 
 
-179
-180
-181</pre>
+157
+158
+159</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 179</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 157</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_ratio'>ratio</span>
   <span class='ivar'>@ratio</span>
@@ -393,12 +393,12 @@
       <pre class="lines">
 
 
-179
-180
-181</pre>
+157
+158
+159</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 179</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 157</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_ratios'>ratios</span>
   <span class='ivar'>@ratios</span>
@@ -430,12 +430,12 @@
       <pre class="lines">
 
 
-188
-189
-190</pre>
+166
+167
+168</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 188</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 166</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_inspect'>inspect</span>
   <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_ratio'>ratio</span><span class='embexpr_end'>}</span><span class='tstring_content'>: </span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_entries'>entries</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
@@ -460,16 +460,16 @@
       <pre class="lines">
 
 
-192
-193
-194
-195
-196
-197
-198</pre>
+170
+171
+172
+173
+174
+175
+176</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 192</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/approximation.rb', line 170</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_sort_by'>sort_by</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='id identifier rubyid_ratio'>ratio</span><span class='rparen'>)</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_ratios'>ratios</span><span class='op'>|</span>
@@ -488,7 +488,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:25 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/ReducedRatio.html
+++ b/docs/Tonal/ReducedRatio.html
@@ -649,7 +649,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:25 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Step.html
+++ b/docs/Tonal/Step.html
@@ -1352,7 +1352,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/Vector.html
+++ b/docs/Vector.html
@@ -242,7 +242,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:25 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -295,7 +295,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -79,7 +79,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,7 +79,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/docs/method_list.html
+++ b/docs/method_list.html
@@ -94,24 +94,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#<=>-instance_method" title="Tonal::Interval#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Tonal::Interval</small>
+      <span class='object_link'><a href="Tonal/Cents.html#<=>-instance_method" title="Tonal::Cents#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Tonal::Cents</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Hertz.html#<=>-instance_method" title="Tonal::Hertz#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Tonal::Hertz</small>
+      <span class='object_link'><a href="Tonal/Log.html#<=>-instance_method" title="Tonal::Log#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Tonal::Log</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#<=>-instance_method" title="Tonal::Ratio#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Tonal/Interval.html#<=>-instance_method" title="Tonal::Interval#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Tonal::Interval</small>
     </div>
   </li>
   
@@ -126,16 +126,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Cents.html#<=>-instance_method" title="Tonal::Cents#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Tonal::Cents</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#<=>-instance_method" title="Tonal::Ratio#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#<=>-instance_method" title="Tonal::Log#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
-      <small>Tonal::Log</small>
+      <span class='object_link'><a href="Tonal/Hertz.html#<=>-instance_method" title="Tonal::Hertz#&lt;=&gt; (method)">#&lt;=&gt;</a></span>
+      <small>Tonal::Hertz</small>
     </div>
   </li>
   
@@ -166,6 +166,22 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/Log2.html#base-class_method" title="Tonal::Log2.base (method)">base</a></span>
+      <small>Tonal::Log2</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Log.html#base-class_method" title="Tonal::Log.base (method)">base</a></span>
+      <small>Tonal::Log</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/Log.html#base-instance_method" title="Tonal::Log#base (method)">#base</a></span>
       <small>Tonal::Log</small>
     </div>
@@ -174,32 +190,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log2.html#base-class_method" title="Tonal::Log2.base (method)">base</a></span>
-      <small>Tonal::Log2</small>
+      <span class='object_link'><a href="Numeric.html#benedetti_height-instance_method" title="Numeric#benedetti_height (method)">#benedetti_height</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
 
   <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#base-class_method" title="Tonal::Log.base (method)">base</a></span>
-      <small>Tonal::Log</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#benedetti_height-instance_method" title="Tonal::Ratio#benedetti_height (method)">#benedetti_height</a></span>
       <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Numeric.html#benedetti_height-instance_method" title="Numeric#benedetti_height (method)">#benedetti_height</a></span>
-      <small>Numeric</small>
     </div>
   </li>
   
@@ -222,21 +222,13 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio/Approximation.html#by_quotient_walk-instance_method" title="Tonal::Ratio::Approximation#by_quotient_walk (method)">#by_quotient_walk</a></span>
-      <small>Tonal::Ratio::Approximation</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio/Approximation.html#by_superparticular-instance_method" title="Tonal::Ratio::Approximation#by_superparticular (method)">#by_superparticular</a></span>
       <small>Tonal::Ratio::Approximation</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio/Approximation.html#by_tree_path-instance_method" title="Tonal::Ratio::Approximation#by_tree_path (method)">#by_tree_path</a></span>
       <small>Tonal::Ratio::Approximation</small>
@@ -244,7 +236,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#cent_diff-instance_method" title="Tonal::Ratio#cent_diff (method)">#cent_diff</a></span>
       <small>Tonal::Ratio</small>
@@ -252,7 +244,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#cents-instance_method" title="Numeric#cents (method)">#cents</a></span>
       <small>Numeric</small>
@@ -260,7 +252,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#combination-instance_method" title="Tonal::Ratio#combination (method)">#combination</a></span>
       <small>Tonal::Ratio</small>
@@ -268,7 +260,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Comma.html#commas-class_method" title="Tonal::Comma.commas (method)">commas</a></span>
       <small>Tonal::Comma</small>
@@ -276,7 +268,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#consequent-instance_method" title="Tonal::Ratio#consequent (method)">#consequent</a></span>
       <small>Tonal::Ratio</small>
@@ -284,7 +276,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#convert-instance_method" title="Tonal::Step#convert (method)">#convert</a></span>
       <small>Tonal::Step</small>
@@ -292,7 +284,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Integer.html#coprime%3F-instance_method" title="Integer#coprime? (method)">#coprime?</a></span>
       <small>Integer</small>
@@ -300,7 +292,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Integer.html#coprimes-instance_method" title="Integer#coprimes (method)">#coprimes</a></span>
       <small>Integer</small>
@@ -308,7 +300,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Cents.html#default_tolerance-class_method" title="Tonal::Cents.default_tolerance (method)">default_tolerance</a></span>
       <small>Tonal::Cents</small>
@@ -316,9 +308,17 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Array.html#denominators-instance_method" title="Array#denominators (method)">#denominators</a></span>
+      <small>Array</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Array.html#denominize-instance_method" title="Array#denominize (method)">#denominize</a></span>
       <small>Array</small>
     </div>
   </li>
@@ -334,21 +334,13 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Array.html#denominize-instance_method" title="Array#denominize (method)">#denominize</a></span>
-      <small>Array</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#difference-instance_method" title="Tonal::Ratio#difference (method)">#difference</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#div_times-instance_method" title="Tonal::Ratio#div_times (method)">#div_times</a></span>
       <small>Tonal::Ratio</small>
@@ -356,7 +348,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#div_times-instance_method" title="Numeric#div_times (method)">#div_times</a></span>
       <small>Numeric</small>
@@ -364,7 +356,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#ed-class_method" title="Tonal::Ratio.ed (method)">ed</a></span>
       <small>Tonal::Ratio</small>
@@ -372,7 +364,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#efficiency-instance_method" title="Tonal::Step#efficiency (method)">#efficiency</a></span>
       <small>Tonal::Step</small>
@@ -380,7 +372,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#efficiency-instance_method" title="Numeric#efficiency (method)">#efficiency</a></span>
       <small>Numeric</small>
@@ -388,7 +380,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#efficiency-instance_method" title="Tonal::Ratio#efficiency (method)">#efficiency</a></span>
       <small>Tonal::Ratio</small>
@@ -396,7 +388,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#equave-instance_method" title="Tonal::Ratio#equave (method)">#equave</a></span>
       <small>Tonal::Ratio</small>
@@ -404,7 +396,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#equave_reduce-instance_method" title="Tonal::Ratio#equave_reduce (method)">#equave_reduce</a></span>
       <small>Tonal::Ratio</small>
@@ -412,7 +404,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#equave_reduce!-instance_method" title="Tonal::Ratio#equave_reduce! (method)">#equave_reduce!</a></span>
       <small>Tonal::Ratio</small>
@@ -420,7 +412,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Integer.html#factorial-instance_method" title="Integer#factorial (method)">#factorial</a></span>
       <small>Integer</small>
@@ -428,7 +420,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Math.html#factorial-class_method" title="Math.factorial (method)">factorial</a></span>
       <small>Math</small>
@@ -436,7 +428,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#fraction_reduce-instance_method" title="Tonal::Ratio#fraction_reduce (method)">#fraction_reduce</a></span>
       <small>Tonal::Ratio</small>
@@ -444,7 +436,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#hz-instance_method" title="Numeric#hz (method)">#hz</a></span>
       <small>Numeric</small>
@@ -452,9 +444,17 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/ReducedRatio.html#identity-class_method" title="Tonal::ReducedRatio.identity (method)">identity</a></span>
+      <small>Tonal::ReducedRatio</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">#initialize</a></span>
       <small>Tonal::ReducedRatio</small>
     </div>
   </li>
@@ -470,32 +470,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#initialize-instance_method" title="Tonal::Interval#initialize (method)">#initialize</a></span>
-      <small>Tonal::Interval</small>
+      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#initialize-instance_method" title="Tonal::Ratio::Approximation::Set#initialize (method)">#initialize</a></span>
+      <small>Tonal::Ratio::Approximation::Set</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">#initialize</a></span>
-      <small>Tonal::Log</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#initialize-instance_method" title="Tonal::Step#initialize (method)">#initialize</a></span>
-      <small>Tonal::Step</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">#initialize</a></span>
-      <small>Tonal::Cents</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#initialize-instance_method" title="Tonal::Ratio#initialize (method)">#initialize</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -510,24 +494,40 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#initialize-instance_method" title="Tonal::Ratio::Approximation::Set#initialize (method)">#initialize</a></span>
-      <small>Tonal::Ratio::Approximation::Set</small>
+      <span class='object_link'><a href="Tonal/Step.html#initialize-instance_method" title="Tonal::Step#initialize (method)">#initialize</a></span>
+      <small>Tonal::Step</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">#initialize</a></span>
-      <small>Tonal::ReducedRatio</small>
+      <span class='object_link'><a href="Tonal/Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">#initialize</a></span>
+      <small>Tonal::Log</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#initialize-instance_method" title="Tonal::Ratio#initialize (method)">#initialize</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Tonal/Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">#initialize</a></span>
+      <small>Tonal::Cents</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Interval.html#initialize-instance_method" title="Tonal::Interval#initialize (method)">#initialize</a></span>
+      <small>Tonal::Interval</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Hertz.html#inspect-instance_method" title="Tonal::Hertz#inspect (method)">#inspect</a></span>
+      <small>Tonal::Hertz</small>
     </div>
   </li>
   
@@ -550,37 +550,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Hertz.html#inspect-instance_method" title="Tonal::Hertz#inspect (method)">#inspect</a></span>
-      <small>Tonal::Hertz</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#inspect-instance_method" title="Tonal::Step#inspect (method)">#inspect</a></span>
       <small>Tonal::Step</small>
     </div>
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#inspect-instance_method" title="Tonal::Log#inspect (method)">#inspect</a></span>
-      <small>Tonal::Log</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#inspect-instance_method" title="Tonal::Interval#inspect (method)">#inspect</a></span>
-      <small>Tonal::Interval</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#inspect-instance_method" title="Tonal::Ratio::Approximation::Set#inspect (method)">#inspect</a></span>
       <small>Tonal::Ratio::Approximation::Set</small>
@@ -588,18 +564,26 @@
   </li>
   
 
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Interval.html#inspect-instance_method" title="Tonal::Interval#inspect (method)">#inspect</a></span>
+      <small>Tonal::Interval</small>
+    </div>
+  </li>
+  
+
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#interval-instance_method" title="Tonal::Interval#interval (method)">#interval</a></span>
-      <small>Tonal::Interval</small>
+      <span class='object_link'><a href="Tonal/Log.html#inspect-instance_method" title="Tonal::Log#inspect (method)">#inspect</a></span>
+      <small>Tonal::Log</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/ReducedRatio.html#interval_with-instance_method" title="Tonal::ReducedRatio#interval_with (method)">#interval_with</a></span>
-      <small>Tonal::ReducedRatio</small>
+      <span class='object_link'><a href="Tonal/Interval.html#interval-instance_method" title="Tonal::Interval#interval (method)">#interval</a></span>
+      <small>Tonal::Interval</small>
     </div>
   </li>
   
@@ -614,13 +598,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/ReducedRatio.html#interval_with-instance_method" title="Tonal::ReducedRatio#interval_with (method)">#interval_with</a></span>
+      <small>Tonal::ReducedRatio</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#invert-instance_method" title="Tonal::Ratio#invert (method)">#invert</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/ReducedRatio.html#invert!-instance_method" title="Tonal::ReducedRatio#invert! (method)">#invert!</a></span>
       <small>Tonal::ReducedRatio</small>
@@ -628,7 +620,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#invert!-instance_method" title="Tonal::Ratio#invert! (method)">#invert!</a></span>
       <small>Tonal::Ratio</small>
@@ -636,7 +628,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Comma.html#keys-class_method" title="Tonal::Comma.keys (method)">keys</a></span>
       <small>Tonal::Comma</small>
@@ -644,7 +636,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#label-instance_method" title="Tonal::Ratio#label (method)">#label</a></span>
       <small>Tonal::Ratio</small>
@@ -652,7 +644,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Array.html#lcm-instance_method" title="Array#lcm (method)">#lcm</a></span>
       <small>Array</small>
@@ -660,7 +652,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#lcm-instance_method" title="Tonal::Ratio#lcm (method)">#lcm</a></span>
       <small>Tonal::Ratio</small>
@@ -668,7 +660,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#log-instance_method" title="Numeric#log (method)">#log</a></span>
       <small>Numeric</small>
@@ -676,7 +668,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Cents.html#log-instance_method" title="Tonal::Cents#log (method)">#log</a></span>
       <small>Tonal::Cents</small>
@@ -684,7 +676,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#log-instance_method" title="Tonal::Step#log (method)">#log</a></span>
       <small>Tonal::Step</small>
@@ -692,17 +684,9 @@
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Numeric.html#log2-instance_method" title="Numeric#log2 (method)">#log2</a></span>
-      <small>Numeric</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#log_weil_height-instance_method" title="Numeric#log_weil_height (method)">#log_weil_height</a></span>
+      <span class='object_link'><a href="Numeric.html#log2-instance_method" title="Numeric#log2 (method)">#log2</a></span>
       <small>Numeric</small>
     </div>
   </li>
@@ -718,15 +702,15 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#logarithm-instance_method" title="Tonal::Log#logarithm (method)">#logarithm</a></span>
-      <small>Tonal::Log</small>
+      <span class='object_link'><a href="Numeric.html#log_weil_height-instance_method" title="Numeric#log_weil_height (method)">#log_weil_height</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#logarithmand-instance_method" title="Tonal::Log#logarithmand (method)">#logarithmand</a></span>
+      <span class='object_link'><a href="Tonal/Log.html#logarithm-instance_method" title="Tonal::Log#logarithm (method)">#logarithm</a></span>
       <small>Tonal::Log</small>
     </div>
   </li>
@@ -734,16 +718,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#lower_ratio-instance_method" title="Tonal::Interval#lower_ratio (method)">#lower_ratio</a></span>
-      <small>Tonal::Interval</small>
+      <span class='object_link'><a href="Tonal/Log.html#logarithmand-instance_method" title="Tonal::Log#logarithmand (method)">#logarithmand</a></span>
+      <small>Tonal::Log</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#max_prime-instance_method" title="Tonal::Ratio#max_prime (method)">#max_prime</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Tonal/Interval.html#lower_ratio-instance_method" title="Tonal::Interval#lower_ratio (method)">#lower_ratio</a></span>
+      <small>Tonal::Interval</small>
     </div>
   </li>
   
@@ -758,23 +742,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#max_prime-instance_method" title="Numeric#max_prime (method)">#max_prime</a></span>
-      <small>Numeric</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Array.html#mean-instance_method" title="Array#mean (method)">#mean</a></span>
-      <small>Array</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#mediant_sum-instance_method" title="Tonal::Ratio#mediant_sum (method)">#mediant_sum</a></span>
+      <span class='object_link'><a href="Tonal/Ratio.html#max_prime-instance_method" title="Tonal::Ratio#max_prime (method)">#max_prime</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
@@ -782,8 +750,24 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Comma.html#method_missing-class_method" title="Tonal::Comma.method_missing (method)">method_missing</a></span>
-      <small>Tonal::Comma</small>
+      <span class='object_link'><a href="Numeric.html#max_prime-instance_method" title="Numeric#max_prime (method)">#max_prime</a></span>
+      <small>Numeric</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Array.html#mean-instance_method" title="Array#mean (method)">#mean</a></span>
+      <small>Array</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#mediant_sum-instance_method" title="Tonal::Ratio#mediant_sum (method)">#mediant_sum</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -798,16 +782,16 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#min_prime-instance_method" title="Tonal::Ratio#min_prime (method)">#min_prime</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Tonal/Comma.html#method_missing-class_method" title="Tonal::Comma.method_missing (method)">method_missing</a></span>
+      <small>Tonal::Comma</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#min_prime-instance_method" title="Numeric#min_prime (method)">#min_prime</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Ratio.html#min_prime-instance_method" title="Tonal::Ratio#min_prime (method)">#min_prime</a></span>
+      <small>Tonal::Ratio</small>
     </div>
   </li>
   
@@ -822,7 +806,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#mirror-instance_method" title="Numeric#mirror (method)">#mirror</a></span>
+      <span class='object_link'><a href="Numeric.html#min_prime-instance_method" title="Numeric#min_prime (method)">#min_prime</a></span>
       <small>Numeric</small>
     </div>
   </li>
@@ -838,16 +822,16 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#modulo-instance_method" title="Tonal::Step#modulo (method)">#modulo</a></span>
-      <small>Tonal::Step</small>
+      <span class='object_link'><a href="Numeric.html#mirror-instance_method" title="Numeric#mirror (method)">#mirror</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#modulo_translate-instance_method" title="Numeric#modulo_translate (method)">#modulo_translate</a></span>
-      <small>Numeric</small>
+      <span class='object_link'><a href="Tonal/Step.html#modulo-instance_method" title="Tonal::Step#modulo (method)">#modulo</a></span>
+      <small>Tonal::Step</small>
     </div>
   </li>
   
@@ -862,13 +846,21 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Numeric.html#modulo_translate-instance_method" title="Numeric#modulo_translate (method)">#modulo_translate</a></span>
+      <small>Numeric</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/Cents.html#nearest_hundredth-instance_method" title="Tonal::Cents#nearest_hundredth (method)">#nearest_hundredth</a></span>
       <small>Tonal::Cents</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Cents.html#nearest_hundredth_difference-instance_method" title="Tonal::Cents#nearest_hundredth_difference (method)">#nearest_hundredth_difference</a></span>
       <small>Tonal::Cents</small>
@@ -876,7 +868,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#negative-instance_method" title="Numeric#negative (method)">#negative</a></span>
       <small>Numeric</small>
@@ -884,7 +876,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#negative-instance_method" title="Tonal::Ratio#negative (method)">#negative</a></span>
       <small>Tonal::Ratio</small>
@@ -892,7 +884,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio/Approximation.html#neighborhood-instance_method" title="Tonal::Ratio::Approximation#neighborhood (method)">#neighborhood</a></span>
       <small>Tonal::Ratio::Approximation</small>
@@ -900,7 +892,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio/Approximation.html#neighbors-class_method" title="Tonal::Ratio::Approximation.neighbors (method)">neighbors</a></span>
       <small>Tonal::Ratio::Approximation</small>
@@ -908,7 +900,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Integer.html#nsmooth-instance_method" title="Integer#nsmooth (method)">#nsmooth</a></span>
       <small>Integer</small>
@@ -916,7 +908,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Array.html#numerators-instance_method" title="Array#numerators (method)">#numerators</a></span>
       <small>Array</small>
@@ -924,7 +916,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#period_degrees-instance_method" title="Numeric#period_degrees (method)">#period_degrees</a></span>
       <small>Numeric</small>
@@ -932,7 +924,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#period_degrees-instance_method" title="Tonal::Ratio#period_degrees (method)">#period_degrees</a></span>
       <small>Tonal::Ratio</small>
@@ -940,7 +932,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#period_radians-instance_method" title="Tonal::Ratio#period_radians (method)">#period_radians</a></span>
       <small>Tonal::Ratio</small>
@@ -948,7 +940,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Integer.html#phi-instance_method" title="Integer#phi (method)">#phi</a></span>
       <small>Integer</small>
@@ -956,7 +948,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#planar_degrees-instance_method" title="Tonal::Ratio#planar_degrees (method)">#planar_degrees</a></span>
       <small>Tonal::Ratio</small>
@@ -964,7 +956,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#planar_radians-instance_method" title="Tonal::Ratio#planar_radians (method)">#planar_radians</a></span>
       <small>Tonal::Ratio</small>
@@ -972,7 +964,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#plus_minus-instance_method" title="Tonal::Ratio#plus_minus (method)">#plus_minus</a></span>
       <small>Tonal::Ratio</small>
@@ -980,7 +972,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Cents.html#plus_minus-instance_method" title="Tonal::Cents#plus_minus (method)">#plus_minus</a></span>
       <small>Tonal::Cents</small>
@@ -988,17 +980,9 @@
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Numeric.html#plus_minus-instance_method" title="Numeric#plus_minus (method)">#plus_minus</a></span>
-      <small>Numeric</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#prime_divisions-instance_method" title="Numeric#prime_divisions (method)">#prime_divisions</a></span>
+      <span class='object_link'><a href="Numeric.html#plus_minus-instance_method" title="Numeric#plus_minus (method)">#plus_minus</a></span>
       <small>Numeric</small>
     </div>
   </li>
@@ -1014,8 +998,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#prime_vector-instance_method" title="Tonal::Ratio#prime_vector (method)">#prime_vector</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Numeric.html#prime_divisions-instance_method" title="Numeric#prime_divisions (method)">#prime_divisions</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
@@ -1030,7 +1014,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#random_ratio-class_method" title="Tonal::Ratio.random_ratio (method)">random_ratio</a></span>
+      <span class='object_link'><a href="Tonal/Ratio.html#prime_vector-instance_method" title="Tonal::Ratio#prime_vector (method)">#prime_vector</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
@@ -1038,8 +1022,24 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#random_ratio-class_method" title="Tonal::Ratio.random_ratio (method)">random_ratio</a></span>
+      <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#ratio-instance_method" title="Tonal::Ratio#ratio (method)">#ratio</a></span>
       <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Step.html#ratio-instance_method" title="Tonal::Step#ratio (method)">#ratio</a></span>
+      <small>Tonal::Step</small>
     </div>
   </li>
   
@@ -1062,21 +1062,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#ratio-instance_method" title="Tonal::Step#ratio (method)">#ratio</a></span>
-      <small>Tonal::Step</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#ratio-instance_method" title="Tonal::Ratio::Approximation::Set#ratio (method)">#ratio</a></span>
       <small>Tonal::Ratio::Approximation::Set</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Array.html#ratio_from_prime_divisions-instance_method" title="Array#ratio_from_prime_divisions (method)">#ratio_from_prime_divisions</a></span>
       <small>Array</small>
@@ -1084,7 +1076,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#ratio_to_cents-instance_method" title="Tonal::Step#ratio_to_cents (method)">#ratio_to_cents</a></span>
       <small>Tonal::Step</small>
@@ -1092,7 +1084,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#ratio_to_r-instance_method" title="Tonal::Step#ratio_to_r (method)">#ratio_to_r</a></span>
       <small>Tonal::Step</small>
@@ -1100,7 +1092,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#ratios-instance_method" title="Tonal::Ratio::Approximation::Set#ratios (method)">#ratios</a></span>
       <small>Tonal::Ratio::Approximation::Set</small>
@@ -1108,7 +1100,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#reduced_antecedent-instance_method" title="Tonal::Ratio#reduced_antecedent (method)">#reduced_antecedent</a></span>
       <small>Tonal::Ratio</small>
@@ -1116,7 +1108,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#reduced_consequent-instance_method" title="Tonal::Ratio#reduced_consequent (method)">#reduced_consequent</a></span>
       <small>Tonal::Ratio</small>
@@ -1124,7 +1116,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Array.html#rescale-instance_method" title="Array#rescale (method)">#rescale</a></span>
       <small>Array</small>
@@ -1132,7 +1124,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Array.html#rpad-instance_method" title="Array#rpad (method)">#rpad</a></span>
       <small>Array</small>
@@ -1140,7 +1132,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Array.html#rpad!-instance_method" title="Array#rpad! (method)">#rpad!</a></span>
       <small>Array</small>
@@ -1148,7 +1140,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#scale-instance_method" title="Tonal::Ratio#scale (method)">#scale</a></span>
       <small>Tonal::Ratio</small>
@@ -1156,7 +1148,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#shear-instance_method" title="Tonal::Ratio#shear (method)">#shear</a></span>
       <small>Tonal::Ratio</small>
@@ -1164,7 +1156,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#sort_by-instance_method" title="Tonal::Ratio::Approximation::Set#sort_by (method)">#sort_by</a></span>
       <small>Tonal::Ratio::Approximation::Set</small>
@@ -1172,26 +1164,18 @@
   </li>
   
 
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#step-instance_method" title="Tonal::Ratio#step (method)">#step</a></span>
-      <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
   <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Numeric.html#step-instance_method" title="Numeric#step (method)">#step</a></span>
-      <small>Numeric</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#step-instance_method" title="Tonal::Step#step (method)">#step</a></span>
       <small>Tonal::Step</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Numeric.html#step-instance_method" title="Numeric#step (method)">#step</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
@@ -1206,13 +1190,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#step-instance_method" title="Tonal::Ratio#step (method)">#step</a></span>
+      <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#step_to_cents-instance_method" title="Tonal::Step#step_to_cents (method)">#step_to_cents</a></span>
       <small>Tonal::Step</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#step_to_r-instance_method" title="Tonal::Step#step_to_r (method)">#step_to_r</a></span>
       <small>Tonal::Step</small>
@@ -1220,7 +1212,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#superparticular-class_method" title="Tonal::Ratio.superparticular (method)">superparticular</a></span>
       <small>Tonal::Ratio</small>
@@ -1228,7 +1220,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#superpartient-class_method" title="Tonal::Ratio.superpartient (method)">superpartient</a></span>
       <small>Tonal::Ratio</small>
@@ -1236,18 +1228,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#tempered-instance_method" title="Tonal::Step#tempered (method)">#tempered</a></span>
       <small>Tonal::Step</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Numeric.html#tenney_height-instance_method" title="Numeric#tenney_height (method)">#tenney_height</a></span>
-      <small>Numeric</small>
     </div>
   </li>
   
@@ -1262,8 +1246,8 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#to_a-instance_method" title="Tonal::Ratio#to_a (method)">#to_a</a></span>
-      <small>Tonal::Ratio</small>
+      <span class='object_link'><a href="Numeric.html#tenney_height-instance_method" title="Numeric#tenney_height (method)">#tenney_height</a></span>
+      <small>Numeric</small>
     </div>
   </li>
   
@@ -1278,8 +1262,24 @@
 
   <li class="odd ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#to_a-instance_method" title="Tonal::Ratio#to_a (method)">#to_a</a></span>
+      <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/ReducedRatio.html#to_basic_ratio-instance_method" title="Tonal::ReducedRatio#to_basic_ratio (method)">#to_basic_ratio</a></span>
       <small>Tonal::ReducedRatio</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Array.html#to_cents-instance_method" title="Array#to_cents (method)">#to_cents</a></span>
+      <small>Array</small>
     </div>
   </li>
   
@@ -1294,22 +1294,6 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#to_cents-instance_method" title="Tonal::Ratio#to_cents (method)">#to_cents</a></span>
-      <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Array.html#to_cents-instance_method" title="Array#to_cents (method)">#to_cents</a></span>
-      <small>Array</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Log.html#to_cents-instance_method" title="Tonal::Log#to_cents (method)">#to_cents</a></span>
       <small>Tonal::Log</small>
     </div>
@@ -1318,7 +1302,7 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#to_f-instance_method" title="Tonal::Ratio#to_f (method)">#to_f</a></span>
+      <span class='object_link'><a href="Tonal/Ratio.html#to_cents-instance_method" title="Tonal::Ratio#to_cents (method)">#to_cents</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
@@ -1334,13 +1318,21 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#to_log-instance_method" title="Tonal::Ratio#to_log (method)">#to_log</a></span>
+      <span class='object_link'><a href="Tonal/Ratio.html#to_f-instance_method" title="Tonal::Ratio#to_f (method)">#to_f</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
   <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#to_log-instance_method" title="Tonal::Ratio#to_log (method)">#to_log</a></span>
+      <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#to_log2-instance_method" title="Tonal::Ratio#to_log2 (method)">#to_log2</a></span>
       <small>Tonal::Ratio</small>
@@ -1348,7 +1340,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Hertz.html#to_r-instance_method" title="Tonal::Hertz#to_r (method)">#to_r</a></span>
       <small>Tonal::Hertz</small>
@@ -1356,7 +1348,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#to_r-instance_method" title="Tonal::Ratio#to_r (method)">#to_r</a></span>
       <small>Tonal::Ratio</small>
@@ -1364,7 +1356,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#to_ratio-instance_method" title="Numeric#to_ratio (method)">#to_ratio</a></span>
       <small>Numeric</small>
@@ -1372,7 +1364,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Vector.html#to_ratio-instance_method" title="Vector#to_ratio (method)">#to_ratio</a></span>
       <small>Vector</small>
@@ -1380,7 +1372,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#to_reduced_ratio-instance_method" title="Tonal::Ratio#to_reduced_ratio (method)">#to_reduced_ratio</a></span>
       <small>Tonal::Ratio</small>
@@ -1388,7 +1380,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#to_v-instance_method" title="Tonal::Ratio#to_v (method)">#to_v</a></span>
       <small>Tonal::Ratio</small>
@@ -1396,7 +1388,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#to_vector-instance_method" title="Numeric#to_vector (method)">#to_vector</a></span>
       <small>Numeric</small>
@@ -1404,7 +1396,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Array.html#to_vector-instance_method" title="Array#to_vector (method)">#to_vector</a></span>
       <small>Array</small>
@@ -1412,7 +1404,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Array.html#translate-instance_method" title="Array#translate (method)">#translate</a></span>
       <small>Array</small>
@@ -1420,7 +1412,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#translate-instance_method" title="Tonal::Ratio#translate (method)">#translate</a></span>
       <small>Tonal::Ratio</small>
@@ -1428,7 +1420,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Interval.html#upper_ratio-instance_method" title="Tonal::Interval#upper_ratio (method)">#upper_ratio</a></span>
       <small>Tonal::Interval</small>
@@ -1436,7 +1428,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Hertz.html#value-instance_method" title="Tonal::Hertz#value (method)">#value</a></span>
       <small>Tonal::Hertz</small>
@@ -1444,7 +1436,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Cents.html#value-instance_method" title="Tonal::Cents#value (method)">#value</a></span>
       <small>Tonal::Cents</small>
@@ -1452,7 +1444,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Comma.html#values-class_method" title="Tonal::Comma.values (method)">values</a></span>
       <small>Tonal::Comma</small>
@@ -1460,7 +1452,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#weil_height-instance_method" title="Numeric#weil_height (method)">#weil_height</a></span>
       <small>Numeric</small>
@@ -1468,9 +1460,17 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#weil_height-instance_method" title="Tonal::Ratio#weil_height (method)">#weil_height</a></span>
+      <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#wilson_height-instance_method" title="Tonal::Ratio#wilson_height (method)">#wilson_height</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
@@ -1486,21 +1486,13 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#wilson_height-instance_method" title="Tonal::Ratio#wilson_height (method)">#wilson_height</a></span>
-      <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Prime.html#within-class_method" title="Prime.within (method)">within</a></span>
       <small>Prime</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#within_cents%3F-class_method" title="Tonal::Ratio.within_cents? (method)">within_cents?</a></span>
       <small>Tonal::Ratio</small>
@@ -1508,7 +1500,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#within_prime%3F-instance_method" title="Tonal::Ratio#within_prime? (method)">#within_prime?</a></span>
       <small>Tonal::Ratio</small>
@@ -1516,7 +1508,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#%C2%A2-instance_method" title="Numeric#¢ (method)">#¢</a></span>
       <small>Numeric</small>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -102,7 +102,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sun Apr  7 20:47:20 2024 by
+  Generated on Sat Aug 31 22:39:24 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.36 (ruby-3.2.2).
 </div>

--- a/lib/tonal/approximation.rb
+++ b/lib/tonal/approximation.rb
@@ -41,28 +41,6 @@ class Tonal::Ratio
       end
     end
 
-    # @return [Tonal::Ratio::Approximation::Set] of ratios within cent tolerance of self found using a quotient walk on the fraction tree
-    # @example
-    #   Tonal::Ratio.ed(12,1).approximate.by_quotient_walk(max_prime: 89)
-    #   => (4771397596969315/4503599627370496): [(17/16), (18/17), (35/33), (53/50), (71/67), (89/84), (196/185)]
-    # @param cents_tolerance the cents tolerance used to scope the collection
-    # @param depth the maximum number of ratios in the collection
-    # @param max_prime the maximum prime number to allow in the collection
-    # @param conv_limit the number of convergents to limit the ContinuedFraction method
-    #
-    def by_quotient_walk(cents_tolerance: Tonal::Cents::TOLERANCE, depth: DEFAULT_FRACTION_TREE_DEPTH, max_prime: DEFAULT_MAX_PRIME, conv_limit: CONVERGENT_LIMIT)
-      self_in_cents = to_cents
-      within = cents_tolerance.kind_of?(Tonal::Cents) ? cents_tolerance : Tonal::Cents.new(cents: cents_tolerance)
-
-      Set.new(ratio: ratio) do |ratios|
-        FractionTree.quotient_walk(to_f, limit: conv_limit).each do |node|
-          ratio2 = ratio.class.new(node.weight)
-          ratios << ratio2 if ratio.class.within_cents?(self_in_cents, ratio2.to_cents, within) && ratio2.within_prime?(max_prime)
-          break if ratios.length >= depth
-        end
-      end
-    end
-
     # @return [Tonal::Ratio::Approximation::Set] of fraction tree ratios within cent tolerance of self
     # @example
     #   Tonal::Ratio.ed(12,1).approximate.by_tree_path(max_prime: 17)
@@ -75,8 +53,8 @@ class Tonal::Ratio
       self_in_cents = to_cents
       within = cents_tolerance.kind_of?(Tonal::Cents) ? cents_tolerance : Tonal::Cents.new(cents: cents_tolerance)
       Set.new(ratio: ratio) do |ratios|
-        FractionTree.path_to(to_f).each do |node|
-          ratio2 = ratio.class.new(node.weight)
+        FractionTree.node(to_f).path.each do |node|
+          ratio2 = ratio.class.new(node.number)
           ratios << ratio2 if ratio.class.within_cents?(self_in_cents, ratio2.to_cents, within) && ratio2.within_prime?(max_prime)
           break if ratios.length >= depth
         end

--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "5.1.2"
+  TOOLS_VERSION = "5.1.3"
 end

--- a/lib/tonal/extensions.rb
+++ b/lib/tonal/extensions.rb
@@ -32,7 +32,7 @@ class Numeric
   # @return [Array] a tuple of self divided and multiplied by factor
   # @example
   #   Math::PI.div_times(3) => [1.0471975511965976, 9.42477796076938]
-  # @param [Numeric]
+  # @param factor [Numeric]
   #
   def div_times(factor) = [self / factor, self * factor]
 
@@ -329,7 +329,7 @@ class Array
   # @return [Tonal::ReducedRatio] ratio reconstructed from the result of a prime factor decomposition
   # @example
   #   [[[3, 1]], [[2, 1]]].ratio_from_prime_divisions => (3/2)
-  # @reduced [Boolean] if a reduced or unreduced ratio is returned
+  # @param reduced [Boolean] if a reduced or unreduced ratio is returned
   #
   def ratio_from_prime_divisions(reduced: false) = reduced ? Tonal::ReducedRatio.new(Prime.int_from_prime_division(self.first), Prime.int_from_prime_division(self.last)) : Tonal::Ratio.new(Prime.int_from_prime_division(self.first), Prime.int_from_prime_division(self.last))
 

--- a/spec/tonal_tools/approximation_spec.rb
+++ b/spec/tonal_tools/approximation_spec.rb
@@ -50,15 +50,6 @@ RSpec.describe Tonal::Ratio::Approximation do
       end
     end
 
-    describe "#by_quotient_walk" do
-      let(:ratio) { Tonal::Ratio.ed(12,1) }
-      let(:max_prime) { 89 }
-
-      it "returns ratios with max prime" do
-        expect(ratio.approximate.by_quotient_walk(max_prime: max_prime).entries).to eq [(17/16r), (18/17r), (35/33r), (53/50r), (71/67r), (89/84r), (196/185r)]
-      end
-    end
-
     describe "#by_tree_path" do
       let(:ratio) { Tonal::Ratio.ed(12,1) }
       let(:depth) { 10 }

--- a/tonal-tools.gemspec
+++ b/tonal-tools.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "matrix", ["~> 0.4"]
   spec.add_runtime_dependency "sorted_set", ["~> 1.0"]
   spec.add_runtime_dependency "continued_fractions", ["~> 2.1"]
-  spec.add_runtime_dependency "fraction-tree", ["~> 1.1"]
+  spec.add_runtime_dependency "fraction-tree", ["~> 2.0"]
   spec.add_development_dependency "rspec", ["~> 3.2"]
   spec.add_development_dependency "byebug", ["~> 11.1"]
   spec.add_development_dependency "yard", ["~> 0.9"]


### PR DESCRIPTION
We want to stay up-to-date with the fraction-tree gem.

This commit adapts to the new fraction-tree api.

It also removes the Approximation#by_quotient_walk methods. The method is redundant. It produces the same results as Approximation#by_tree_path.