### PR TITLE
Update fraction-tree version

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "5.1.3"
+  TOOLS_VERSION = "5.1.4"
 end

--- a/spec/tonal_tools/approximation_spec.rb
+++ b/spec/tonal_tools/approximation_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe Tonal::Ratio::Approximation do
     end
 
     describe "#by_superparticular" do
-      let(:ratio) { Tonal::Ratio.new(3/2r)}
+      let(:ratio) { Tonal::Ratio.new(3/2r) }
       let(:depth) { 5 }
 
       it "returns approximations by descending superparticulars factored by ratio" do

--- a/tonal-tools.gemspec
+++ b/tonal-tools.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "matrix", ["~> 0.4"]
   spec.add_runtime_dependency "sorted_set", ["~> 1.0"]
   spec.add_runtime_dependency "continued_fractions", ["~> 2.1"]
-  spec.add_runtime_dependency "fraction-tree", ["~> 2.0"]
+  spec.add_runtime_dependency "fraction-tree", ["~> 2.1"]
   spec.add_development_dependency "rspec", ["~> 3.2"]
   spec.add_development_dependency "byebug", ["~> 11.1"]
   spec.add_development_dependency "yard", ["~> 0.9"]


### PR DESCRIPTION
We want to keep up with new features of fraction-tree.

This change updates the gemspec, requiring the latest fraction-tree version.