### PR TITLE
Add Numeric#log_floor

### DIFF
--- a/docs/Array.html
+++ b/docs/Array.html
@@ -499,10 +499,10 @@
       <pre class="lines">
 
 
-312</pre>
+313</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 312</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 313</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_denominators'>denominators</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:denominator</span><span class='rparen'>)</span></pre>
     </td>
@@ -562,13 +562,13 @@
       <pre class="lines">
 
 
-319
 320
 321
-322</pre>
+322
+323</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 319</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 320</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_denominize'>denominize</span>
   <span class='id identifier rubyid_l'>l</span> <span class='op'>=</span> <span class='id identifier rubyid_denominators'>denominators</span><span class='period'>.</span><span class='id identifier rubyid_lcm'>lcm</span>
@@ -631,10 +631,10 @@
       <pre class="lines">
 
 
-299</pre>
+300</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 299</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 300</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_lcm'>lcm</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_reduce'>reduce</span><span class='lparen'>(</span><span class='int'>1</span><span class='comma'>,</span> <span class='symbol'>:lcm</span><span class='rparen'>)</span></pre>
     </td>
@@ -694,10 +694,10 @@
       <pre class="lines">
 
 
-335</pre>
+336</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 335</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 336</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mean'>mean</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_sum'>sum</span> <span class='op'>/</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_count'>count</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span></pre>
     </td>
@@ -796,15 +796,15 @@
       <pre class="lines">
 
 
-375
 376
 377
 378
 379
-380</pre>
+380
+381</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 375</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 376</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_modulo_translate'>modulo_translate</span><span class='lparen'>(</span><span class='id identifier rubyid_lower'>lower</span><span class='op'>=</span><span class='int'>0</span><span class='comma'>,</span> <span class='id identifier rubyid_upper'>upper</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_range'>range</span> <span class='op'>=</span> <span class='lparen'>(</span><span class='id identifier rubyid_upper'>upper</span> <span class='op'>-</span> <span class='id identifier rubyid_lower'>lower</span><span class='rparen'>)</span> <span class='op'>==</span> <span class='int'>0</span> <span class='op'>?</span> <span class='int'>1</span> <span class='op'>:</span> <span class='id identifier rubyid_upper'>upper</span> <span class='op'>-</span> <span class='id identifier rubyid_lower'>lower</span>
@@ -873,10 +873,10 @@
       <pre class="lines">
 
 
-305</pre>
+306</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 305</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 306</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_numerators'>numerators</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:numerator</span><span class='rparen'>)</span></pre>
     </td>
@@ -958,10 +958,10 @@
       <pre class="lines">
 
 
-342</pre>
+343</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 342</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 343</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_ratio_from_prime_divisions'>ratio_from_prime_divisions</span><span class='lparen'>(</span><span class='label'>reduced:</span> <span class='kw'>false</span><span class='rparen'>)</span> <span class='op'>=</span> <span class='id identifier rubyid_reduced'>reduced</span> <span class='op'>?</span> <span class='const'><span class='object_link'><a href="Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Tonal/ReducedRatio.html" title="Tonal::ReducedRatio (class)">ReducedRatio</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Tonal/ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="Prime.html" title="Prime (class)">Prime</a></span></span><span class='period'>.</span><span class='id identifier rubyid_int_from_prime_division'>int_from_prime_division</span><span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='const'><span class='object_link'><a href="Prime.html" title="Prime (class)">Prime</a></span></span><span class='period'>.</span><span class='id identifier rubyid_int_from_prime_division'>int_from_prime_division</span><span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_last'>last</span><span class='rparen'>)</span><span class='rparen'>)</span> <span class='op'>:</span> <span class='const'><span class='object_link'><a href="Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Tonal/Ratio.html" title="Tonal::Ratio (class)">Ratio</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Tonal/Ratio.html#initialize-instance_method" title="Tonal::Ratio#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="Prime.html" title="Prime (class)">Prime</a></span></span><span class='period'>.</span><span class='id identifier rubyid_int_from_prime_division'>int_from_prime_division</span><span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='const'><span class='object_link'><a href="Prime.html" title="Prime (class)">Prime</a></span></span><span class='period'>.</span><span class='id identifier rubyid_int_from_prime_division'>int_from_prime_division</span><span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_last'>last</span><span class='rparen'>)</span><span class='rparen'>)</span></pre>
     </td>
@@ -1050,17 +1050,17 @@
       <pre class="lines">
 
 
-359
 360
 361
 362
 363
 364
 365
-366</pre>
+366
+367</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 359</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 360</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_rescale'>rescale</span><span class='lparen'>(</span><span class='id identifier rubyid_new_min'>new_min</span><span class='op'>=</span><span class='int'>0</span><span class='comma'>,</span> <span class='id identifier rubyid_new_max'>new_max</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_old_min'>old_min</span> <span class='op'>=</span> <span class='id identifier rubyid_min'>min</span>
@@ -1155,10 +1155,10 @@
       <pre class="lines">
 
 
-286</pre>
+287</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 286</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 287</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_rpad'>rpad</span><span class='lparen'>(</span><span class='id identifier rubyid_min_size'>min_size</span><span class='comma'>,</span> <span class='id identifier rubyid_value'>value</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='rparen'>)</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_dup'>dup</span><span class='period'>.</span><span class='id identifier rubyid_rpad!'>rpad!</span><span class='lparen'>(</span><span class='id identifier rubyid_min_size'>min_size</span><span class='comma'>,</span> <span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span></pre>
     </td>
@@ -1246,13 +1246,13 @@
       <pre class="lines">
 
 
-275
 276
 277
-278</pre>
+278
+279</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 275</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 276</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_rpad!'>rpad!</span><span class='lparen'>(</span><span class='id identifier rubyid_min_size'>min_size</span><span class='comma'>,</span> <span class='id identifier rubyid_value'>value</span> <span class='op'>=</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_length'>length</span> <span class='op'>&gt;</span> <span class='id identifier rubyid_min_size'>min_size</span> <span class='op'>?</span> <span class='kw'>self</span> <span class='op'>:</span> <span class='lparen'>(</span><span class='id identifier rubyid_min_size'>min_size</span> <span class='op'>-</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_length'>length</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_times'>times</span> <span class='lbrace'>{</span> <span class='kw'>self</span> <span class='op'>&lt;&lt;</span> <span class='id identifier rubyid_value'>value</span> <span class='rbrace'>}</span>
@@ -1319,10 +1319,10 @@
       <pre class="lines">
 
 
-328</pre>
+329</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 328</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 329</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_cents'>to_cents</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lbrace'>{</span><span class='op'>|</span><span class='id identifier rubyid_r'>r</span><span class='op'>|</span> <span class='id identifier rubyid_r'>r</span><span class='period'>.</span><span class='id identifier rubyid_to_cents'>to_cents</span><span class='rbrace'>}</span></pre>
     </td>
@@ -1386,10 +1386,10 @@
       <pre class="lines">
 
 
-292</pre>
+293</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 292</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 293</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_vector'>to_vector</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Vector.html" title="Vector (class)">Vector</a></span></span><span class='lbracket'>[</span><span class='op'>*</span><span class='kw'>self</span><span class='rbracket'>]</span></pre>
     </td>
@@ -1469,10 +1469,10 @@
       <pre class="lines">
 
 
-349</pre>
+350</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 349</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 350</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_translate'>translate</span><span class='lparen'>(</span><span class='id identifier rubyid_value'>value</span><span class='rparen'>)</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lbrace'>{</span><span class='op'>|</span><span class='id identifier rubyid_e'>e</span><span class='op'>|</span> <span class='id identifier rubyid_e'>e</span> <span class='op'>+</span> <span class='id identifier rubyid_value'>value</span><span class='rbrace'>}</span></pre>
     </td>
@@ -1485,7 +1485,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:24 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Integer.html
+++ b/docs/Integer.html
@@ -117,7 +117,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#coprime%3F-instance_method" title="#coprime? (instance method)">#<strong>coprime?</strong>(i)  &#x21d2; Boolean </a>
+      <a href="#coprime%3F-instance_method" title="#coprime? (instance method)">#<strong>coprime?</strong>(other)  &#x21d2; Boolean </a>
     
 
     
@@ -132,7 +132,7 @@
 
   
     <span class="summary_desc"><div class='inline'>
-<p>If self is coprime with i.</p>
+<p>If self is coprime with other number.</p>
 </div></span>
   
 </li>
@@ -296,7 +296,7 @@
       <div class="method_details first">
   <h3 class="signature first" id="coprime?-instance_method">
   
-    #<strong>coprime?</strong>(i)  &#x21d2; <tt>Boolean</tt> 
+    #<strong>coprime?</strong>(other)  &#x21d2; <tt>Boolean</tt> 
   
 
   
@@ -305,7 +305,7 @@
 </h3><div class="docstring">
   <div class="discussion">
     
-<p>Returns if self is coprime with i.</p>
+<p>Returns if self is coprime with other number.</p>
 
 
   </div>
@@ -320,6 +320,26 @@
 <span class='int'>25</span><span class='period'>.</span><span class='id identifier rubyid_coprime?'>coprime?</span><span class='lparen'>(</span><span class='int'>5</span><span class='rparen'>)</span> <span class='op'>=&gt;</span> <span class='kw'>false</span></code></pre>
     
   </div>
+<p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>other</span>
+      
+      
+        <span class='type'></span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>number determining coprimeness</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 <p class="tag_title">Returns:</p>
 <ul class="return">
@@ -333,7 +353,7 @@
       
         &mdash;
         <div class='inline'>
-<p>if self is coprime with i</p>
+<p>if self is coprime with other number</p>
 </div>
       
     </li>
@@ -346,12 +366,12 @@
       <pre class="lines">
 
 
-220</pre>
+221</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 220</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 221</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_coprime?'>coprime?</span><span class='lparen'>(</span><span class='id identifier rubyid_i'>i</span><span class='rparen'>)</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_gcd'>gcd</span><span class='lparen'>(</span><span class='id identifier rubyid_i'>i</span><span class='rparen'>)</span> <span class='op'>==</span> <span class='int'>1</span></pre>
+<span class='kw'>def</span> <span class='id identifier rubyid_coprime?'>coprime?</span><span class='lparen'>(</span><span class='id identifier rubyid_other'>other</span><span class='rparen'>)</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_gcd'>gcd</span><span class='lparen'>(</span><span class='id identifier rubyid_other'>other</span><span class='rparen'>)</span> <span class='op'>==</span> <span class='int'>1</span></pre>
     </td>
   </tr>
 </table>
@@ -409,16 +429,16 @@
       <pre class="lines">
 
 
-226
 227
 228
 229
 230
 231
-232</pre>
+232
+233</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 226</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 227</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_coprimes'>coprimes</span>
   <span class='lbracket'>[</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_tap'>tap</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_coprime_set'>coprime_set</span><span class='op'>|</span>
@@ -691,7 +711,6 @@
       <pre class="lines">
 
 
-248
 249
 250
 251
@@ -708,10 +727,11 @@
 262
 263
 264
-265</pre>
+265
+266</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 248</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 249</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_nsmooth'>nsmooth</span><span class='lparen'>(</span><span class='id identifier rubyid_limit'>limit</span><span class='op'>=</span><span class='int'>2</span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='lbracket'>[</span><span class='int'>0</span><span class='rbracket'>]</span> <span class='op'>*</span> <span class='id identifier rubyid_limit'>limit</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_tap'>tap</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_ns'>ns</span><span class='op'>|</span>
@@ -792,10 +812,10 @@
       <pre class="lines">
 
 
-238</pre>
+239</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 238</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 239</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_phi'>phi</span> <span class='op'>=</span> <span class='id identifier rubyid_coprimes'>coprimes</span><span class='period'>.</span><span class='id identifier rubyid_count'>count</span></pre>
     </td>
@@ -808,7 +828,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:24 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Math.html
+++ b/docs/Math.html
@@ -214,10 +214,10 @@
       <pre class="lines">
 
 
-400</pre>
+401</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 400</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 401</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_factorial'>factorial</span><span class='lparen'>(</span><span class='id identifier rubyid_limit'>limit</span><span class='rparen'>)</span> <span class='op'>=</span> <span class='lparen'>(</span><span class='int'>2</span><span class='op'>..</span><span class='id identifier rubyid_limit'>limit</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_reduce'>reduce</span><span class='lparen'>(</span><span class='int'>1</span><span class='comma'>,</span> <span class='symbol'>:*</span><span class='rparen'>)</span></pre>
     </td>
@@ -230,7 +230,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Numeric.html
+++ b/docs/Numeric.html
@@ -167,30 +167,6 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#decimal_power-instance_method" title="#decimal_power (instance method)">#<strong>decimal_power</strong>  &#x21d2; Integer </a>
-    
-
-    
-  </span>
-  
-  
-  
-  
-  
-  
-  
-
-  
-    <span class="summary_desc"><div class='inline'>
-<p>The decimal power of self.</p>
-</div></span>
-  
-</li>
-
-      
-        <li class="public ">
-  <span class="summary_signature">
-    
       <a href="#div_times-instance_method" title="#div_times (instance method)">#<strong>div_times</strong>(factor)  &#x21d2; Array </a>
     
 
@@ -331,6 +307,30 @@
   
     <span class="summary_desc"><div class='inline'>
 <p>The log2 of self.</p>
+</div></span>
+  
+</li>
+
+      
+        <li class="public ">
+  <span class="summary_signature">
+    
+      <a href="#log_floor-instance_method" title="#log_floor (instance method)">#<strong>log_floor</strong>(base = 10)  &#x21d2; Integer </a>
+    
+
+    
+  </span>
+  
+  
+  
+  
+  
+  
+  
+
+  
+    <span class="summary_desc"><div class='inline'>
+<p>The floor of the log (to the given base) of self.</p>
 </div></span>
   
 </li>
@@ -918,73 +918,6 @@
 </div>
     
       <div class="method_details ">
-  <h3 class="signature " id="decimal_power-instance_method">
-  
-    #<strong>decimal_power</strong>  &#x21d2; <tt><span class='object_link'><a href="Integer.html" title="Integer (class)">Integer</a></span></tt> 
-  
-
-  
-
-  
-</h3><div class="docstring">
-  <div class="discussion">
-    
-<p>Returns the decimal power of self.</p>
-
-
-  </div>
-</div>
-<div class="tags">
-  
-  <div class="examples">
-    <h4 class="tag_title">Examples:</h4>
-    
-      
-      <pre class="example code"><code><span class='lparen'>(</span><span class='int'>3</span><span class='op'>/</span><span class='rational'>2r</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_decimal_power'>decimal_power</span> <span class='op'>=&gt;</span> <span class='int'>0</span></code></pre>
-    
-  </div>
-
-<p class="tag_title">Returns:</p>
-<ul class="return">
-  
-    <li>
-      
-      
-        <span class='type'>(<tt><span class='object_link'><a href="Integer.html" title="Integer (class)">Integer</a></span></tt>)</span>
-      
-      
-      
-        &mdash;
-        <div class='inline'>
-<p>the decimal power of self</p>
-</div>
-      
-    </li>
-  
-</ul>
-
-</div><table class="source_code">
-  <tr>
-    <td>
-      <pre class="lines">
-
-
-189
-190
-191</pre>
-    </td>
-    <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 189</span>
-
-<span class='kw'>def</span> <span class='id identifier rubyid_decimal_power'>decimal_power</span>
-  <span class='const'><span class='object_link'><a href="Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log10'>log10</span><span class='lparen'>(</span><span class='kw'>self</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_floor'>floor</span>
-<span class='kw'>end</span></pre>
-    </td>
-  </tr>
-</table>
-</div>
-    
-      <div class="method_details ">
   <h3 class="signature " id="div_times-instance_method">
   
     #<strong>div_times</strong>(factor)  &#x21d2; <tt><span class='object_link'><a href="Array.html" title="Array (class)">Array</a></span></tt> 
@@ -1408,6 +1341,91 @@
 </div>
     
       <div class="method_details ">
+  <h3 class="signature " id="log_floor-instance_method">
+  
+    #<strong>log_floor</strong>(base = 10)  &#x21d2; <tt><span class='object_link'><a href="Integer.html" title="Integer (class)">Integer</a></span></tt> 
+  
+
+  
+
+  
+</h3><div class="docstring">
+  <div class="discussion">
+    
+<p>Returns the floor of the log (to the given base) of self.</p>
+
+
+  </div>
+</div>
+<div class="tags">
+  
+  <div class="examples">
+    <h4 class="tag_title">Examples:</h4>
+    
+      
+      <pre class="example code"><code><span class='const'><span class='object_link'><a href="Math.html" title="Math (module)">Math</a></span></span><span class='op'>::</span><span class='const'>PI</span><span class='period'>.</span><span class='id identifier rubyid_log_floor'>log_floor</span><span class='lparen'>(</span><span class='int'>2</span><span class='rparen'>)</span> <span class='op'>=&gt;</span> <span class='int'>1</span></code></pre>
+    
+  </div>
+<p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>base</span>
+      
+      
+        <span class='type'></span>
+      
+      
+        <em class="default">(defaults to: <tt>10</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>of the log</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+<p class="tag_title">Returns:</p>
+<ul class="return">
+  
+    <li>
+      
+      
+        <span class='type'>(<tt><span class='object_link'><a href="Integer.html" title="Integer (class)">Integer</a></span></tt>)</span>
+      
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>the floor of the log (to the given base) of self</p>
+</div>
+      
+    </li>
+  
+</ul>
+
+</div><table class="source_code">
+  <tr>
+    <td>
+      <pre class="lines">
+
+
+191</pre>
+    </td>
+    <td>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 191</span>
+
+<span class='kw'>def</span> <span class='id identifier rubyid_log_floor'>log_floor</span><span class='lparen'>(</span><span class='id identifier rubyid_base'>base</span><span class='op'>=</span><span class='int'>10</span><span class='rparen'>)</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log'>log</span><span class='lparen'>(</span><span class='kw'>self</span><span class='comma'>,</span> <span class='id identifier rubyid_base'>base</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_floor'>floor</span></pre>
+    </td>
+  </tr>
+</table>
+</div>
+    
+      <div class="method_details ">
   <h3 class="signature " id="log_weil_height-instance_method">
   
     #<strong>log_weil_height</strong>  &#x21d2; <tt><span class='object_link'><a href="Tonal/Log2.html" title="Tonal::Log2 (class)">Tonal::Log2</a></span></tt> 
@@ -1622,6 +1640,28 @@
       <pre class="example code"><code>(3/2r).mirror =&gt; (4/3)</code></pre>
     
   </div>
+<p class="tag_title">Parameters:</p>
+<ul class="param">
+  
+    <li>
+      
+        <span class='name'>axis</span>
+      
+      
+        <span class='type'></span>
+      
+      
+        <em class="default">(defaults to: <tt>1</tt>)</em>
+      
+      
+        &mdash;
+        <div class='inline'>
+<p>around which self is mirrored</p>
+</div>
+      
+    </li>
+  
+</ul>
 
 <p class="tag_title">Returns:</p>
 <ul class="return">
@@ -1648,10 +1688,10 @@
       <pre class="lines">
 
 
-183</pre>
+184</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 183</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 184</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mirror'>mirror</span><span class='lparen'>(</span><span class='id identifier rubyid_axis'>axis</span><span class='op'>=</span><span class='int'>1</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_mirror'>mirror</span><span class='lparen'>(</span><span class='id identifier rubyid_axis'>axis</span><span class='rparen'>)</span></pre>
     </td>
@@ -2652,7 +2692,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:24 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Prime.html
+++ b/docs/Prime.html
@@ -253,7 +253,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal.html
+++ b/docs/Tonal.html
@@ -112,7 +112,7 @@
         <dt id="TOOLS_VERSION-constant" class="">TOOLS_VERSION =
           
         </dt>
-        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>5.2.0</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>5.3.0</span><span class='tstring_end'>&quot;</span></span></pre></dd>
       
     </dl>
   
@@ -128,7 +128,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Cents.html
+++ b/docs/Tonal/Cents.html
@@ -1226,7 +1226,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Comma.html
+++ b/docs/Tonal/Comma.html
@@ -498,7 +498,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Hertz.html
+++ b/docs/Tonal/Hertz.html
@@ -822,7 +822,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Interval.html
+++ b/docs/Tonal/Interval.html
@@ -687,7 +687,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Log.html
+++ b/docs/Tonal/Log.html
@@ -1016,7 +1016,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Log2.html
+++ b/docs/Tonal/Log2.html
@@ -216,7 +216,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Ratio.html
+++ b/docs/Tonal/Ratio.html
@@ -6236,7 +6236,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Ratio/Approximation.html
+++ b/docs/Tonal/Ratio/Approximation.html
@@ -1415,7 +1415,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:24 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Ratio/Approximation/Set.html
+++ b/docs/Tonal/Ratio/Approximation/Set.html
@@ -488,7 +488,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:24 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/ReducedRatio.html
+++ b/docs/Tonal/ReducedRatio.html
@@ -649,7 +649,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:24 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Tonal/Step.html
+++ b/docs/Tonal/Step.html
@@ -1352,7 +1352,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/Vector.html
+++ b/docs/Vector.html
@@ -226,10 +226,10 @@
       <pre class="lines">
 
 
-390</pre>
+391</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 390</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/extensions.rb', line 391</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_ratio'>to_ratio</span><span class='lparen'>(</span><span class='label'>reduced:</span> <span class='kw'>true</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span> <span class='op'>=</span> <span class='id identifier rubyid_reduced'>reduced</span> <span class='op'>?</span> <span class='const'><span class='object_link'><a href="Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Tonal/ReducedRatio.html" title="Tonal::ReducedRatio (class)">ReducedRatio</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Tonal/ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='op'>*</span><span class='kw'>self</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span> <span class='op'>:</span> <span class='const'><span class='object_link'><a href="Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Tonal/Ratio.html" title="Tonal::Ratio (class)">Ratio</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Tonal/Ratio.html#initialize-instance_method" title="Tonal::Ratio#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='op'>*</span><span class='kw'>self</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span></pre>
     </td>
@@ -242,7 +242,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:24 2024 by
+  Generated on Sat Nov  9 16:11:23 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -295,7 +295,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -79,7 +79,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -79,7 +79,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/docs/method_list.html
+++ b/docs/method_list.html
@@ -169,8 +169,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#base-class_method" title="Tonal::Log.base (method)">base</a></span>
-      <small>Tonal::Log</small>
+      <span class='object_link'><a href="Tonal/Log2.html#base-class_method" title="Tonal::Log2.base (method)">base</a></span>
+      <small>Tonal::Log2</small>
     </div>
   </li>
   
@@ -185,8 +185,8 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log2.html#base-class_method" title="Tonal::Log2.base (method)">base</a></span>
-      <small>Tonal::Log2</small>
+      <span class='object_link'><a href="Tonal/Log.html#base-class_method" title="Tonal::Log.base (method)">base</a></span>
+      <small>Tonal::Log</small>
     </div>
   </li>
   
@@ -305,31 +305,15 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Numeric.html#decimal_power-instance_method" title="Numeric#decimal_power (method)">#decimal_power</a></span>
-      <small>Numeric</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Cents.html#default_tolerance-class_method" title="Tonal::Cents.default_tolerance (method)">default_tolerance</a></span>
       <small>Tonal::Cents</small>
     </div>
   </li>
   
 
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Array.html#denominators-instance_method" title="Array#denominators (method)">#denominators</a></span>
-      <small>Array</small>
-    </div>
-  </li>
-  
-
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Array.html#denominize-instance_method" title="Array#denominize (method)">#denominize</a></span>
+      <span class='object_link'><a href="Array.html#denominators-instance_method" title="Array#denominators (method)">#denominators</a></span>
       <small>Array</small>
     </div>
   </li>
@@ -345,13 +329,21 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Array.html#denominize-instance_method" title="Array#denominize (method)">#denominize</a></span>
+      <small>Array</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#difference-instance_method" title="Tonal::Ratio#difference (method)">#difference</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#div_times-instance_method" title="Numeric#div_times (method)">#div_times</a></span>
       <small>Numeric</small>
@@ -359,7 +351,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#div_times-instance_method" title="Tonal::Ratio#div_times (method)">#div_times</a></span>
       <small>Tonal::Ratio</small>
@@ -367,7 +359,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#ed-class_method" title="Tonal::Ratio.ed (method)">ed</a></span>
       <small>Tonal::Ratio</small>
@@ -375,7 +367,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#efficiency-instance_method" title="Tonal::Ratio#efficiency (method)">#efficiency</a></span>
       <small>Tonal::Ratio</small>
@@ -383,7 +375,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#efficiency-instance_method" title="Numeric#efficiency (method)">#efficiency</a></span>
       <small>Numeric</small>
@@ -391,7 +383,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Step.html#efficiency-instance_method" title="Tonal::Step#efficiency (method)">#efficiency</a></span>
       <small>Tonal::Step</small>
@@ -399,7 +391,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#equave-instance_method" title="Tonal::Ratio#equave (method)">#equave</a></span>
       <small>Tonal::Ratio</small>
@@ -407,7 +399,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#equave_reduce-instance_method" title="Tonal::Ratio#equave_reduce (method)">#equave_reduce</a></span>
       <small>Tonal::Ratio</small>
@@ -415,7 +407,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#equave_reduce!-instance_method" title="Tonal::Ratio#equave_reduce! (method)">#equave_reduce!</a></span>
       <small>Tonal::Ratio</small>
@@ -423,7 +415,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Integer.html#factorial-instance_method" title="Integer#factorial (method)">#factorial</a></span>
       <small>Integer</small>
@@ -431,7 +423,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Math.html#factorial-class_method" title="Math.factorial (method)">factorial</a></span>
       <small>Math</small>
@@ -439,7 +431,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#fraction_reduce-instance_method" title="Tonal::Ratio#fraction_reduce (method)">#fraction_reduce</a></span>
       <small>Tonal::Ratio</small>
@@ -447,7 +439,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#hz-instance_method" title="Numeric#hz (method)">#hz</a></span>
       <small>Numeric</small>
@@ -455,7 +447,7 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/ReducedRatio.html#identity-class_method" title="Tonal::ReducedRatio.identity (method)">identity</a></span>
       <small>Tonal::ReducedRatio</small>
@@ -463,26 +455,18 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Hertz.html#initialize-instance_method" title="Tonal::Hertz#initialize (method)">#initialize</a></span>
-      <small>Tonal::Hertz</small>
+      <span class='object_link'><a href="Tonal/Ratio/Approximation.html#initialize-instance_method" title="Tonal::Ratio::Approximation#initialize (method)">#initialize</a></span>
+      <small>Tonal::Ratio::Approximation</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#initialize-instance_method" title="Tonal::Ratio#initialize (method)">#initialize</a></span>
       <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">#initialize</a></span>
-      <small>Tonal::Log</small>
     </div>
   </li>
   
@@ -497,71 +481,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio/Approximation.html#initialize-instance_method" title="Tonal::Ratio::Approximation#initialize (method)">#initialize</a></span>
-      <small>Tonal::Ratio::Approximation</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">#initialize</a></span>
-      <small>Tonal::ReducedRatio</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">#initialize</a></span>
-      <small>Tonal::Cents</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#initialize-instance_method" title="Tonal::Interval#initialize (method)">#initialize</a></span>
-      <small>Tonal::Interval</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#initialize-instance_method" title="Tonal::Ratio::Approximation::Set#initialize (method)">#initialize</a></span>
-      <small>Tonal::Ratio::Approximation::Set</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#inspect-instance_method" title="Tonal::Ratio#inspect (method)">#inspect</a></span>
-      <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#inspect-instance_method" title="Tonal::Step#inspect (method)">#inspect</a></span>
-      <small>Tonal::Step</small>
-    </div>
-  </li>
-  
-
-  <li class="even ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Cents.html#inspect-instance_method" title="Tonal::Cents#inspect (method)">#inspect</a></span>
-      <small>Tonal::Cents</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Hertz.html#inspect-instance_method" title="Tonal::Hertz#inspect (method)">#inspect</a></span>
+      <span class='object_link'><a href="Tonal/Hertz.html#initialize-instance_method" title="Tonal::Hertz#initialize (method)">#initialize</a></span>
       <small>Tonal::Hertz</small>
     </div>
   </li>
@@ -569,23 +489,23 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#inspect-instance_method" title="Tonal::Interval#inspect (method)">#inspect</a></span>
-      <small>Tonal::Interval</small>
+      <span class='object_link'><a href="Tonal/Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">#initialize</a></span>
+      <small>Tonal::Log</small>
     </div>
   </li>
   
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Log.html#inspect-instance_method" title="Tonal::Log#inspect (method)">#inspect</a></span>
-      <small>Tonal::Log</small>
+      <span class='object_link'><a href="Tonal/ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">#initialize</a></span>
+      <small>Tonal::ReducedRatio</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#inspect-instance_method" title="Tonal::Ratio::Approximation::Set#inspect (method)">#inspect</a></span>
+      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#initialize-instance_method" title="Tonal::Ratio::Approximation::Set#initialize (method)">#initialize</a></span>
       <small>Tonal::Ratio::Approximation::Set</small>
     </div>
   </li>
@@ -593,7 +513,7 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Interval.html#interval-instance_method" title="Tonal::Interval#interval (method)">#interval</a></span>
+      <span class='object_link'><a href="Tonal/Interval.html#initialize-instance_method" title="Tonal::Interval#initialize (method)">#initialize</a></span>
       <small>Tonal::Interval</small>
     </div>
   </li>
@@ -601,13 +521,85 @@
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">#initialize</a></span>
+      <small>Tonal::Cents</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#inspect-instance_method" title="Tonal::Ratio#inspect (method)">#inspect</a></span>
+      <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Step.html#inspect-instance_method" title="Tonal::Step#inspect (method)">#inspect</a></span>
+      <small>Tonal::Step</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Cents.html#inspect-instance_method" title="Tonal::Cents#inspect (method)">#inspect</a></span>
+      <small>Tonal::Cents</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Hertz.html#inspect-instance_method" title="Tonal::Hertz#inspect (method)">#inspect</a></span>
+      <small>Tonal::Hertz</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Interval.html#inspect-instance_method" title="Tonal::Interval#inspect (method)">#inspect</a></span>
+      <small>Tonal::Interval</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Log.html#inspect-instance_method" title="Tonal::Log#inspect (method)">#inspect</a></span>
+      <small>Tonal::Log</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio/Approximation/Set.html#inspect-instance_method" title="Tonal::Ratio::Approximation::Set#inspect (method)">#inspect</a></span>
+      <small>Tonal::Ratio::Approximation::Set</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Interval.html#interval-instance_method" title="Tonal::Interval#interval (method)">#interval</a></span>
+      <small>Tonal::Interval</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Tonal/ReducedRatio.html#interval_with-instance_method" title="Tonal::ReducedRatio#interval_with (method)">#interval_with</a></span>
       <small>Tonal::ReducedRatio</small>
     </div>
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Numeric.html#interval_with-instance_method" title="Numeric#interval_with (method)">#interval_with</a></span>
       <small>Numeric</small>
@@ -615,9 +607,17 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#invert-instance_method" title="Tonal::Ratio#invert (method)">#invert</a></span>
+      <small>Tonal::Ratio</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Tonal/Ratio.html#invert!-instance_method" title="Tonal::Ratio#invert! (method)">#invert!</a></span>
       <small>Tonal::Ratio</small>
     </div>
   </li>
@@ -633,21 +633,13 @@
 
   <li class="even ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Ratio.html#invert!-instance_method" title="Tonal::Ratio#invert! (method)">#invert!</a></span>
-      <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
       <span class='object_link'><a href="Tonal/Comma.html#keys-class_method" title="Tonal::Comma.keys (method)">keys</a></span>
       <small>Tonal::Comma</small>
     </div>
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#label-instance_method" title="Tonal::Ratio#label (method)">#label</a></span>
       <small>Tonal::Ratio</small>
@@ -655,7 +647,7 @@
   </li>
   
 
-  <li class="odd ">
+  <li class="even ">
     <div class="item">
       <span class='object_link'><a href="Array.html#lcm-instance_method" title="Array#lcm (method)">#lcm</a></span>
       <small>Array</small>
@@ -663,18 +655,10 @@
   </li>
   
 
-  <li class="even ">
+  <li class="odd ">
     <div class="item">
       <span class='object_link'><a href="Tonal/Ratio.html#lcm-instance_method" title="Tonal::Ratio#lcm (method)">#lcm</a></span>
       <small>Tonal::Ratio</small>
-    </div>
-  </li>
-  
-
-  <li class="odd ">
-    <div class="item">
-      <span class='object_link'><a href="Tonal/Cents.html#log-instance_method" title="Tonal::Cents#log (method)">#log</a></span>
-      <small>Tonal::Cents</small>
     </div>
   </li>
   
@@ -689,15 +673,31 @@
 
   <li class="odd ">
     <div class="item">
-      <span class='object_link'><a href="Tonal/Step.html#log-instance_method" title="Tonal::Step#log (method)">#log</a></span>
-      <small>Tonal::Step</small>
+      <span class='object_link'><a href="Tonal/Cents.html#log-instance_method" title="Tonal::Cents#log (method)">#log</a></span>
+      <small>Tonal::Cents</small>
     </div>
   </li>
   
 
   <li class="even ">
     <div class="item">
+      <span class='object_link'><a href="Tonal/Step.html#log-instance_method" title="Tonal::Step#log (method)">#log</a></span>
+      <small>Tonal::Step</small>
+    </div>
+  </li>
+  
+
+  <li class="odd ">
+    <div class="item">
       <span class='object_link'><a href="Numeric.html#log2-instance_method" title="Numeric#log2 (method)">#log2</a></span>
+      <small>Numeric</small>
+    </div>
+  </li>
+  
+
+  <li class="even ">
+    <div class="item">
+      <span class='object_link'><a href="Numeric.html#log_floor-instance_method" title="Numeric#log_floor (method)">#log_floor</a></span>
       <small>Numeric</small>
     </div>
   </li>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -102,7 +102,7 @@
 </div>
 
       <div id="footer">
-  Generated on Fri Nov  8 19:54:23 2024 by
+  Generated on Sat Nov  9 16:11:22 2024 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.2.2).
 </div>

--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "5.2.0"
+  TOOLS_VERSION = "5.3.0"
 end

--- a/lib/tonal/extensions.rb
+++ b/lib/tonal/extensions.rb
@@ -179,16 +179,16 @@ class Numeric
   # @return [Tonal::ReducedRatio], the ratio rotated on the given axis, default 1/1
   # @example
   #   (3/2r).mirror => (4/3)
+  # @param axis around which self is mirrored
   #
   def mirror(axis=1/1r) = self.ratio.mirror(axis)
 
-  # @return [Integer] the decimal power of self
+  # @return [Integer] the floor of the log (to the given base) of self
   # @example
-  #   (3/2r).decimal_power => 0
+  #   Math::PI.log_floor(2) => 1
+  # @param base of the log
   #
-  def decimal_power
-    Math.log10(self).floor
-  end
+  def log_floor(base=10) = Math.log(self, base).floor
 end
 
 class Integer
@@ -212,12 +212,13 @@ class Integer
   #
   def factorial = (2..self).reduce(1, :*)
 
-  # @return [Boolean] if self is coprime with i
+  # @return [Boolean] if self is coprime with other number
   # @example
   #   25.coprime?(7) => true
   #   25.coprime?(5) => false
+  # @param other number determining coprimeness
   #
-  def coprime?(i) = self.gcd(i) == 1
+  def coprime?(other) = self.gcd(other) == 1
 
   # @return [Array] list of integers that are coprime with self, up to the value of self
   # @example

--- a/spec/tonal_tools/extensions_spec.rb
+++ b/spec/tonal_tools/extensions_spec.rb
@@ -188,9 +188,15 @@ RSpec.describe "Extensions" do
       end
     end
 
-    describe "#decimal_power" do
-      it "returns the decimal power of self" do
-        expect(22632.decimal_power).to eq 4
+    describe "#log_floor" do
+      it "returns the log floor to the base 10 of self" do
+        expect(22632.log_floor).to eq 4
+      end
+
+      context "with given base" do
+        it "returns the log floor to the given base of self" do
+          expect(22632.log_floor(2)).to eq 14
+        end
       end
     end
   end


### PR DESCRIPTION
Add Numeric#log_floor
    
Finding the log floor for a given base of a number is useful when determining
its scale, size or digit length.
    
This commit adds the #log_floor method to the Numeric class. It replaces the
Numberic#decimal_power method.