### PR TITLE
Add the precision constant in more classes

### DIFF
--- a/docs/Array.html
+++ b/docs/Array.html
@@ -1572,7 +1572,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Integer.html
+++ b/docs/Integer.html
@@ -836,7 +836,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Interval.html
+++ b/docs/Interval.html
@@ -164,7 +164,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Math.html
+++ b/docs/Math.html
@@ -230,7 +230,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Numeric.html
+++ b/docs/Numeric.html
@@ -2692,7 +2692,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Prime.html
+++ b/docs/Prime.html
@@ -253,7 +253,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Ratio.html
+++ b/docs/Ratio.html
@@ -144,12 +144,12 @@
       <pre class="lines">
 
 
-623
-624
-625</pre>
+625
+626
+627</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 623</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 625</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='op'>[]</span><span class='lparen'>(</span><span class='id identifier rubyid_u'>u</span><span class='comma'>,</span> <span class='id identifier rubyid_l'>l</span><span class='op'>=</span><span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Tonal/Ratio.html" title="Tonal::Ratio (class)">Ratio</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Tonal/Ratio.html#initialize-instance_method" title="Tonal::Ratio#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_u'>u</span><span class='comma'>,</span> <span class='id identifier rubyid_l'>l</span><span class='rparen'>)</span>
@@ -164,7 +164,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/ReducedRatio.html
+++ b/docs/ReducedRatio.html
@@ -164,7 +164,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal.html
+++ b/docs/Tonal.html
@@ -114,7 +114,7 @@
         <dt id="TOOLS_VERSION-constant" class="">TOOLS_VERSION =
           
         </dt>
-        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>6.1.0</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>6.1.1</span><span class='tstring_end'>&quot;</span></span></pre></dd>
       
     </dl>
   
@@ -225,7 +225,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Cents.html
+++ b/docs/Tonal/Cents.html
@@ -1226,7 +1226,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Comma.html
+++ b/docs/Tonal/Comma.html
@@ -498,7 +498,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Hertz.html
+++ b/docs/Tonal/Hertz.html
@@ -822,7 +822,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/IRBHelpers.html
+++ b/docs/Tonal/IRBHelpers.html
@@ -412,7 +412,7 @@
     <h4 class="tag_title">Examples:</h4>
     
       
-      <pre class="example code"><code>r(3,3) =&gt; (1/1)</code></pre>
+      <pre class="example code"><code>rr(3,3) =&gt; (1/1)</code></pre>
     
   </div>
 <p class="tag_title">Parameters:</p>
@@ -499,7 +499,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Interval.html
+++ b/docs/Tonal/Interval.html
@@ -758,7 +758,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Log.html
+++ b/docs/Tonal/Log.html
@@ -114,6 +114,22 @@
   <p class="children"><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></p>
 </div>
 
+  
+    <h2>
+      Constant Summary
+      <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+    </h2>
+
+    <dl class="constants">
+      
+        <dt id="PRECISION-constant" class="">PRECISION =
+          
+        </dt>
+        <dd><pre class="code"><span class='int'>2</span></pre></dd>
+      
+    </dl>
+  
+
 
 
 
@@ -465,8 +481,6 @@
       <pre class="lines">
 
 
-16
-17
 18
 19
 20
@@ -496,10 +510,12 @@
 44
 45
 46
-47</pre>
+47
+48
+49</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 16</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 18</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>logarithm:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>base:</span> <span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise'>raise</span> <span class='const'>ArgumentError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>logarithmand or logarithm must be provided</span><span class='tstring_end'>&quot;</span></span> <span class='kw'>if</span> <span class='id identifier rubyid_logarithmand'>logarithmand</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span> <span class='op'>&amp;&amp;</span> <span class='id identifier rubyid_logarithm'>logarithm</span><span class='period'>.</span><span class='id identifier rubyid_nil?'>nil?</span>
@@ -561,8 +577,6 @@
       <pre class="lines">
 
 
-102
-103
 104
 105
 106
@@ -573,10 +587,12 @@
 111
 112
 113
-114</pre>
+114
+115
+116</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 102</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 104</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_method_missing'>method_missing</span><span class='lparen'>(</span><span class='id identifier rubyid_op'>op</span><span class='comma'>,</span> <span class='op'>*</span><span class='id identifier rubyid_args'>args</span><span class='comma'>,</span> <span class='op'>&amp;</span><span class='id identifier rubyid_blk'>blk</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_rhs'>rhs</span> <span class='op'>=</span> <span class='id identifier rubyid_args'>args</span><span class='period'>.</span><span class='id identifier rubyid_collect'>collect</span> <span class='kw'>do</span> <span class='op'>|</span><span class='id identifier rubyid_arg'>arg</span><span class='op'>|</span>
@@ -629,12 +645,12 @@
       <pre class="lines">
 
 
-7
-8
-9</pre>
+9
+10
+11</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 7</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 9</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_base'>base</span>
   <span class='ivar'>@base</span>
@@ -672,12 +688,12 @@
       <pre class="lines">
 
 
-7
-8
-9</pre>
+9
+10
+11</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 7</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 9</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_logarithm'>logarithm</span>
   <span class='ivar'>@logarithm</span>
@@ -715,12 +731,12 @@
       <pre class="lines">
 
 
-7
-8
-9</pre>
+9
+10
+11</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 7</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 9</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_logarithmand'>logarithmand</span>
   <span class='ivar'>@logarithmand</span>
@@ -752,12 +768,12 @@
       <pre class="lines">
 
 
-49
-50
-51</pre>
+51
+52
+53</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 49</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 51</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_base'>base</span>
   <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='op'>::</span><span class='const'>E</span>
@@ -788,12 +804,12 @@
       <pre class="lines">
 
 
-78
-79
-80</pre>
+80
+81
+82</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 78</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 80</span>
 
 <span class='kw'>def</span> <span class='op'>&lt;=&gt;</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_kind_of?'>kind_of?</span><span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='rparen'>)</span> <span class='op'>?</span> <span class='id identifier rubyid_logarithm'>logarithm</span> <span class='op'>&lt;=&gt;</span> <span class='id identifier rubyid_rhs'>rhs</span><span class='period'>.</span><span class='id identifier rubyid_logarithm'>logarithm</span> <span class='op'>:</span> <span class='id identifier rubyid_logarithm'>logarithm</span> <span class='op'>&lt;=&gt;</span> <span class='id identifier rubyid_rhs'>rhs</span>
@@ -855,15 +871,15 @@
       <pre class="lines">
 
 
-74
-75
-76</pre>
+76
+77
+78</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 74</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 76</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_inspect'>inspect</span>
-  <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_logarithm'>logarithm</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='int'>2</span><span class='rparen'>)</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
+  <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_logarithm'>logarithm</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Log::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -922,12 +938,12 @@
       <pre class="lines">
 
 
-66
-67
-68</pre>
+68
+69
+70</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 66</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 68</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_step'>step</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Step.html" title="Tonal::Step (class)">Step</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Step.html#initialize-instance_method" title="Tonal::Step#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>modulo:</span> <span class='id identifier rubyid_modulo'>modulo</span><span class='comma'>,</span> <span class='label'>log:</span> <span class='kw'>self</span><span class='rparen'>)</span>
@@ -996,12 +1012,12 @@
       <pre class="lines">
 
 
-58
-59
-60</pre>
+60
+61
+62</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 58</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/log.rb', line 60</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_cents'>to_cents</span><span class='lparen'>(</span><span class='label'>precision:</span> <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html#PRECISION-constant" title="Tonal::Cents::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>log:</span> <span class='kw'>self</span><span class='comma'>,</span> <span class='label'>precision:</span> <span class='id identifier rubyid_precision'>precision</span><span class='rparen'>)</span>
@@ -1016,7 +1032,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Log2.html
+++ b/docs/Tonal/Log2.html
@@ -104,6 +104,12 @@
 
 
 
+  <h2>Constant Summary</h2>
+  
+  <h3 class="inherited">Constants inherited
+     from <span class='object_link'><a href="Log.html" title="Tonal::Log (class)">Log</a></span></h3>
+  <p class="inherited"><span class='object_link'><a href="Log.html#PRECISION-constant" title="Tonal::Log::PRECISION (constant)">Tonal::Log::PRECISION</a></span></p>
+
 
 
 
@@ -216,7 +222,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Ratio.html
+++ b/docs/Tonal/Ratio.html
@@ -126,6 +126,22 @@
   
 </p>
 
+  
+    <h2>
+      Constant Summary
+      <small><a href="#" class="constants_summary_toggle">collapse</a></small>
+    </h2>
+
+    <dl class="constants">
+      
+        <dt id="PRECISION-constant" class="">PRECISION =
+          
+        </dt>
+        <dd><pre class="code"><span class='int'>2</span></pre></dd>
+      
+    </dl>
+  
+
 
 
 
@@ -1150,7 +1166,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#period_degrees-instance_method" title="#period_degrees (instance method)">#<strong>period_degrees</strong>(round: 2)  &#x21d2; Float </a>
+      <a href="#period_degrees-instance_method" title="#period_degrees (instance method)">#<strong>period_degrees</strong>(round: PRECISION)  &#x21d2; Float </a>
     
 
     
@@ -1174,7 +1190,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#period_radians-instance_method" title="#period_radians (instance method)">#<strong>period_radians</strong>(round: 2)  &#x21d2; Float </a>
+      <a href="#period_radians-instance_method" title="#period_radians (instance method)">#<strong>period_radians</strong>(round: PRECISION)  &#x21d2; Float </a>
     
 
     
@@ -1198,7 +1214,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#planar_degrees-instance_method" title="#planar_degrees (instance method)">#<strong>planar_degrees</strong>(round: 2)  &#x21d2; Float </a>
+      <a href="#planar_degrees-instance_method" title="#planar_degrees (instance method)">#<strong>planar_degrees</strong>(round: PRECISION)  &#x21d2; Float </a>
     
 
     
@@ -1222,7 +1238,7 @@
         <li class="public ">
   <span class="summary_signature">
     
-      <a href="#planar_radians-instance_method" title="#planar_radians (instance method)">#<strong>planar_radians</strong>(round: 2)  &#x21d2; Float </a>
+      <a href="#planar_radians-instance_method" title="#planar_radians (instance method)">#<strong>planar_radians</strong>(round: PRECISION)  &#x21d2; Float </a>
     
 
     
@@ -1794,15 +1810,15 @@
       <pre class="lines">
 
 
-15
-16
 17
 18
 19
-20</pre>
+20
+21
+22</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 15</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 17</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_initialize'>initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='op'>=</span><span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='kw'>nil</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise'>raise</span> <span class='const'>ArgumentError</span><span class='comma'>,</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>Antecedent must be Numeric</span><span class='tstring_end'>&quot;</span></span> <span class='kw'>unless</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_kind_of?'>kind_of?</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Numeric.html" title="Numeric (class)">Numeric</a></span></span><span class='rparen'>)</span>
@@ -1852,12 +1868,12 @@
       <pre class="lines">
 
 
-7
-8
-9</pre>
+9
+10
+11</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 7</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 9</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_antecedent'>antecedent</span>
   <span class='ivar'>@antecedent</span>
@@ -1899,12 +1915,12 @@
       <pre class="lines">
 
 
-7
-8
-9</pre>
+9
+10
+11</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 7</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 9</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_consequent'>consequent</span>
   <span class='ivar'>@consequent</span>
@@ -1942,12 +1958,12 @@
       <pre class="lines">
 
 
-7
-8
-9</pre>
+9
+10
+11</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 7</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 9</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_equave'>equave</span>
   <span class='ivar'>@equave</span>
@@ -1985,12 +2001,12 @@
       <pre class="lines">
 
 
-7
-8
-9</pre>
+9
+10
+11</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 7</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 9</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span>
   <span class='ivar'>@reduced_antecedent</span>
@@ -2028,12 +2044,12 @@
       <pre class="lines">
 
 
-7
-8
-9</pre>
+9
+10
+11</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 7</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 9</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span>
   <span class='ivar'>@reduced_consequent</span>
@@ -2142,12 +2158,12 @@
       <pre class="lines">
 
 
-78
-79
-80</pre>
+80
+81
+82</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 78</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 80</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_ed'>ed</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='comma'>,</span> <span class='id identifier rubyid_step'>step</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='int'>2</span><span class='op'>**</span><span class='lparen'>(</span><span class='id identifier rubyid_step'>step</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span><span class='op'>/</span><span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -2239,8 +2255,6 @@
       <pre class="lines">
 
 
-59
-60
 61
 62
 63
@@ -2248,10 +2262,12 @@
 65
 66
 67
-68</pre>
+68
+69
+70</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 59</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 61</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_random_ratio'>random_ratio</span><span class='lparen'>(</span><span class='id identifier rubyid_number_of_factors'>number_of_factors</span> <span class='op'>=</span> <span class='int'>2</span><span class='comma'>,</span> <span class='label'>within:</span> <span class='int'>100</span><span class='comma'>,</span> <span class='label'>reduced:</span> <span class='kw'>false</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_primes'>primes</span> <span class='op'>=</span> <span class='const'><span class='object_link'><a href="../Prime.html" title="Prime (class)">Prime</a></span></span><span class='period'>.</span><span class='id identifier rubyid_each'>each</span><span class='lparen'>(</span><span class='id identifier rubyid_within'>within</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_a'>to_a</span>
@@ -2376,12 +2392,12 @@
       <pre class="lines">
 
 
-32
-33
-34</pre>
+34
+35
+36</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 32</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 34</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_superparticular'>superparticular</span><span class='lparen'>(</span><span class='id identifier rubyid_n'>n</span><span class='comma'>,</span> <span class='label'>factor:</span> <span class='int'>1</span><span class='op'>/</span><span class='rational'>1r</span><span class='comma'>,</span> <span class='label'>superpart:</span> <span class='symbol'>:upper</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_superpartient'>superpartient</span><span class='lparen'>(</span><span class='id identifier rubyid_n'>n</span><span class='comma'>,</span> <span class='label'>summand:</span> <span class='int'>1</span><span class='comma'>,</span> <span class='label'>factor:</span><span class='comma'>,</span> <span class='label'>superpart:</span><span class='rparen'>)</span>
@@ -2515,17 +2531,17 @@
       <pre class="lines">
 
 
-44
-45
 46
 47
 48
 49
 50
-51</pre>
+51
+52
+53</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 44</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 46</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_superpartient'>superpartient</span><span class='lparen'>(</span><span class='id identifier rubyid_n'>n</span><span class='comma'>,</span> <span class='label'>summand:</span><span class='comma'>,</span> <span class='label'>factor:</span> <span class='int'>1</span><span class='op'>/</span><span class='rational'>1r</span><span class='comma'>,</span> <span class='label'>superpart:</span> <span class='symbol'>:upper</span><span class='rparen'>)</span>
   <span class='kw'>case</span> <span class='id identifier rubyid_superpart'>superpart</span><span class='period'>.</span><span class='id identifier rubyid_to_sym'>to_sym</span><span class='period'>.</span><span class='id identifier rubyid_downcase'>downcase</span>
@@ -2629,12 +2645,12 @@
       <pre class="lines">
 
 
-89
-90
-91</pre>
+91
+92
+93</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 89</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 91</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_within_cents?'>within_cents?</span><span class='lparen'>(</span><span class='id identifier rubyid_cents1'>cents1</span><span class='comma'>,</span> <span class='id identifier rubyid_cents2'>cents2</span><span class='comma'>,</span> <span class='id identifier rubyid_within'>within</span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='id identifier rubyid_cents1'>cents1</span> <span class='op'>-</span> <span class='id identifier rubyid_cents2'>cents2</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_abs'>abs</span> <span class='op'>&lt;=</span> <span class='id identifier rubyid_within'>within</span>
@@ -2665,12 +2681,12 @@
       <pre class="lines">
 
 
-491
-492
-493</pre>
+493
+494
+495</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 491</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 493</span>
 
 <span class='kw'>def</span> <span class='op'>*</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:*</span><span class='rparen'>)</span>
@@ -2695,12 +2711,12 @@
       <pre class="lines">
 
 
-499
-500
-501</pre>
+501
+502
+503</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 499</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 501</span>
 
 <span class='kw'>def</span> <span class='op'>**</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:**</span><span class='rparen'>)</span>
@@ -2725,12 +2741,12 @@
       <pre class="lines">
 
 
-483
-484
-485</pre>
+485
+486
+487</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 483</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 485</span>
 
 <span class='kw'>def</span> <span class='op'>+</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:+</span><span class='rparen'>)</span>
@@ -2755,12 +2771,12 @@
       <pre class="lines">
 
 
-487
-488
-489</pre>
+489
+490
+491</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 487</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 489</span>
 
 <span class='kw'>def</span> <span class='op'>-</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:-</span><span class='rparen'>)</span>
@@ -2785,12 +2801,12 @@
       <pre class="lines">
 
 
-495
-496
-497</pre>
+497
+498
+499</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 495</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 497</span>
 
 <span class='kw'>def</span> <span class='op'>/</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:/</span><span class='rparen'>)</span>
@@ -2815,14 +2831,14 @@
       <pre class="lines">
 
 
-557
-558
 559
 560
-561</pre>
+561
+562
+563</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 557</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 559</span>
 
 <span class='kw'>def</span> <span class='op'>&lt;=&gt;</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_left'>left</span> <span class='op'>=</span> <span class='id identifier rubyid_consequent'>consequent</span> <span class='op'>==</span> <span class='int'>0</span> <span class='op'>?</span> <span class='const'>Float</span><span class='op'>::</span><span class='const'>INFINITY</span> <span class='op'>:</span> <span class='const'>Rational</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rparen'>)</span>
@@ -2878,12 +2894,12 @@
       <pre class="lines">
 
 
-101
-102
-103</pre>
+103
+104
+105</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 101</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 103</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_approximate'>approximate</span>
   <span class='ivar'>@approximation</span>
@@ -2949,12 +2965,12 @@
       <pre class="lines">
 
 
-384
-385
-386</pre>
+386
+387
+388</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 384</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 386</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_benedetti_height'>benedetti_height</span>
   <span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span> <span class='op'>*</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span>
@@ -3036,12 +3052,12 @@
       <pre class="lines">
 
 
-461
-462
-463</pre>
+463
+464
+465</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 461</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 463</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_cent_diff'>cent_diff</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_cents'>cents</span> <span class='op'>-</span> <span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='period'>.</span><span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_cents'>cents</span>
@@ -3107,12 +3123,12 @@
       <pre class="lines">
 
 
-552
-553
-554</pre>
+554
+555
+556</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 552</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 554</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_combination'>combination</span>
   <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>+</span> <span class='id identifier rubyid_consequent'>consequent</span>
@@ -3178,12 +3194,12 @@
       <pre class="lines">
 
 
-543
-544
-545</pre>
+545
+546
+547</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 543</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 545</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_difference'>difference</span>
   <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>-</span> <span class='id identifier rubyid_consequent'>consequent</span>
@@ -3265,13 +3281,13 @@
       <pre class="lines">
 
 
-440
-441
 442
-443</pre>
+443
+444
+445</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 440</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 442</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_div_times'>div_times</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_other_ratio'>other_ratio</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
@@ -3354,14 +3370,14 @@
       <pre class="lines">
 
 
-429
-430
 431
 432
-433</pre>
+433
+434
+435</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 429</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 431</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_efficiency'>efficiency</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span>
   <span class='comment'># We want the efficiency from the ratio (self).
@@ -3451,12 +3467,12 @@
       <pre class="lines">
 
 
-210
-211
-212</pre>
+212
+213
+214</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 210</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 212</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_equave_reduce'>equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='op'>=</span><span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid__equave_reduce'>_equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span><span class='rparen'>)</span>
@@ -3544,13 +3560,13 @@
       <pre class="lines">
 
 
-221
-222
 223
-224</pre>
+224
+225
+226</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 221</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 223</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_equave_reduce!'>equave_reduce!</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='op'>=</span><span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='ivar'>@antecedent</span><span class='comma'>,</span> <span class='ivar'>@consequent</span> <span class='op'>=</span> <span class='id identifier rubyid__equave_reduce'>_equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -3620,12 +3636,12 @@
       <pre class="lines">
 
 
-201
-202
-203</pre>
+203
+204
+205</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 201</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 203</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_fraction_reduce'>fraction_reduce</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_to_r'>to_r</span><span class='rparen'>)</span>
@@ -3691,12 +3707,12 @@
       <pre class="lines">
 
 
-478
-479
-480</pre>
+480
+481
+482</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 478</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 480</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_inspect'>inspect</span>
   <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>(</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_consequent'>consequent</span><span class='embexpr_end'>}</span><span class='tstring_content'>)</span><span class='tstring_end'>&quot;</span></span>
@@ -3787,13 +3803,13 @@
       <pre class="lines">
 
 
-534
-535
 536
-537</pre>
+537
+538
+539</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 534</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 536</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_interval_with'>interval_with</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='op'>=</span><span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_r'>r</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rparen'>)</span>
@@ -3860,12 +3876,12 @@
       <pre class="lines">
 
 
-241
-242
-243</pre>
+243
+244
+245</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 241</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 243</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_invert'>invert</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span>
@@ -3927,13 +3943,13 @@
       <pre class="lines">
 
 
-250
-251
 252
-253</pre>
+253
+254
+255</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 250</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 252</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_invert!'>invert!</span>
   <span class='id identifier rubyid__initialize'>_initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='id identifier rubyid_label'>label</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -3988,21 +4004,21 @@
       <pre class="lines">
 
 
-467
-468
 469
 470
 471
-472</pre>
+472
+473
+474</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 467</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 469</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_label'>label</span>
   <span class='comment'># Return label, if defined; or,
 </span>  <span class='comment'># Return the &quot;antecedent/consequent&quot;, if antecedent is less than 7 digits long; or
 </span>  <span class='comment'># Return the floating point representation rounded to 2 digits of precision
-</span>  <span class='lparen'>(</span><span class='ivar'>@label</span> <span class='op'>||</span> <span class='lparen'>(</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log10'>log10</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_i'>to_i</span> <span class='op'>+</span> <span class='int'>1</span><span class='rparen'>)</span> <span class='op'>&lt;=</span> <span class='int'>6</span> <span class='op'>?</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_consequent'>consequent</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span> <span class='op'>:</span> <span class='id identifier rubyid_to_f'>to_f</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html#PRECISION-constant" title="Tonal::Cents::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span><span class='rparen'>)</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span>
+</span>  <span class='lparen'>(</span><span class='ivar'>@label</span> <span class='op'>||</span> <span class='lparen'>(</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log10'>log10</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_i'>to_i</span> <span class='op'>+</span> <span class='int'>1</span><span class='rparen'>)</span> <span class='op'>&lt;=</span> <span class='int'>6</span> <span class='op'>?</span> <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_consequent'>consequent</span><span class='embexpr_end'>}</span><span class='tstring_end'>&quot;</span></span> <span class='op'>:</span> <span class='id identifier rubyid_to_f'>to_f</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span><span class='rparen'>)</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_to_s'>to_s</span>
 <span class='kw'>end</span></pre>
     </td>
   </tr>
@@ -4081,12 +4097,12 @@
       <pre class="lines">
 
 
-523
-524
-525</pre>
+525
+526
+527</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 523</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 525</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_lcm'>lcm</span><span class='lparen'>(</span><span class='id identifier rubyid_lhs'>lhs</span><span class='rparen'>)</span>
   <span class='lbracket'>[</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span><span class='comma'>,</span> <span class='id identifier rubyid_lhs'>lhs</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_lcm'>lcm</span>
@@ -4148,12 +4164,12 @@
       <pre class="lines">
 
 
-412
-413
-414</pre>
+414
+415
+416</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 412</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 414</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_log_weil_height'>log_weil_height</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_weil_height'>weil_height</span><span class='rparen'>)</span>
@@ -4215,12 +4231,12 @@
       <pre class="lines">
 
 
-359
-360
-361</pre>
+361
+362
+363</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 359</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 361</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_max_prime'>max_prime</span>
   <span class='id identifier rubyid_prime_divisions'>prime_divisions</span><span class='period'>.</span><span class='id identifier rubyid_flatten'>flatten</span><span class='lparen'>(</span><span class='int'>1</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:first</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_max'>max</span>
@@ -4302,12 +4318,12 @@
       <pre class="lines">
 
 
-376
-377
-378</pre>
+378
+379
+380</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 376</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 378</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_max_prime_within?'>max_prime_within?</span><span class='lparen'>(</span><span class='id identifier rubyid_number'>number</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_max_prime'>max_prime</span> <span class='op'>&lt;=</span> <span class='id identifier rubyid_number'>number</span>
@@ -4388,12 +4404,12 @@
       <pre class="lines">
 
 
-508
-509
-510</pre>
+510
+511
+512</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 508</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 510</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mediant_sum'>mediant_sum</span><span class='lparen'>(</span><span class='id identifier rubyid_number'>number</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>+</span> <span class='id identifier rubyid_number'>number</span><span class='period'>.</span><span class='id identifier rubyid_numerator'>numerator</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span> <span class='op'>+</span> <span class='id identifier rubyid_number'>number</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span><span class='rparen'>)</span>
@@ -4455,12 +4471,12 @@
       <pre class="lines">
 
 
-367
-368
-369</pre>
+369
+370
+371</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 367</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 369</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_min_prime'>min_prime</span>
   <span class='id identifier rubyid_prime_divisions'>prime_divisions</span><span class='period'>.</span><span class='id identifier rubyid_flatten'>flatten</span><span class='lparen'>(</span><span class='int'>1</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:first</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_min'>min</span>
@@ -4539,12 +4555,12 @@
       <pre class="lines">
 
 
-260
-261
-262</pre>
+262
+263
+264</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 260</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 262</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mirror'>mirror</span><span class='lparen'>(</span><span class='id identifier rubyid_axis'>axis</span><span class='op'>=</span><span class='int'>1</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_axis'>axis</span><span class='rparen'>)</span> <span class='op'>**</span> <span class='int'>2</span><span class='rparen'>)</span> <span class='op'>/</span> <span class='kw'>self</span>
@@ -4606,12 +4622,12 @@
       <pre class="lines">
 
 
-268
-269
-270</pre>
+270
+271
+272</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 268</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 270</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_negative'>negative</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='int'>3</span><span class='op'>/</span><span class='rational'>2r</span><span class='rparen'>)</span> <span class='op'>/</span> <span class='kw'>self</span>
@@ -4624,7 +4640,7 @@
       <div class="method_details ">
   <h3 class="signature " id="period_degrees-instance_method">
   
-    #<strong>period_degrees</strong>(round: 2)  &#x21d2; <tt>Float</tt> 
+    #<strong>period_degrees</strong>(round: PRECISION)  &#x21d2; <tt>Float</tt> 
   
 
   
@@ -4658,7 +4674,7 @@
         <span class='type'></span>
       
       
-        <em class="default">(defaults to: <tt>2</tt>)</em>
+        <em class="default">(defaults to: <tt>PRECISION</tt>)</em>
       
       
     </li>
@@ -4690,14 +4706,14 @@
       <pre class="lines">
 
 
-183
-184
-185</pre>
+185
+186
+187</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 183</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 185</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_period_degrees'>period_degrees</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='int'>2</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_period_degrees'>period_degrees</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='float'>360.0</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log'>log</span><span class='lparen'>(</span><span class='id identifier rubyid_to_f'>to_f</span><span class='comma'>,</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -4708,7 +4724,7 @@
       <div class="method_details ">
   <h3 class="signature " id="period_radians-instance_method">
   
-    #<strong>period_radians</strong>(round: 2)  &#x21d2; <tt>Float</tt> 
+    #<strong>period_radians</strong>(round: PRECISION)  &#x21d2; <tt>Float</tt> 
   
 
   
@@ -4742,7 +4758,7 @@
         <span class='type'></span>
       
       
-        <em class="default">(defaults to: <tt>2</tt>)</em>
+        <em class="default">(defaults to: <tt>PRECISION</tt>)</em>
       
       
     </li>
@@ -4774,14 +4790,14 @@
       <pre class="lines">
 
 
-192
-193
-194</pre>
+194
+195
+196</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 192</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 194</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_period_radians'>period_radians</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='int'>2</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_period_radians'>period_radians</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='int'>2</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='op'>::</span><span class='const'>PI</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log'>log</span><span class='lparen'>(</span><span class='id identifier rubyid_to_f'>to_f</span><span class='comma'>,</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -4792,7 +4808,7 @@
       <div class="method_details ">
   <h3 class="signature " id="planar_degrees-instance_method">
   
-    #<strong>planar_degrees</strong>(round: 2)  &#x21d2; <tt>Float</tt> 
+    #<strong>planar_degrees</strong>(round: PRECISION)  &#x21d2; <tt>Float</tt> 
   
 
   
@@ -4826,7 +4842,7 @@
         <span class='type'></span>
       
       
-        <em class="default">(defaults to: <tt>2</tt>)</em>
+        <em class="default">(defaults to: <tt>PRECISION</tt>)</em>
       
       
     </li>
@@ -4858,14 +4874,14 @@
       <pre class="lines">
 
 
-316
-317
-318</pre>
+318
+319
+320</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 316</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 318</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_planar_degrees'>planar_degrees</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='int'>2</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_planar_degrees'>planar_degrees</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_atan2'>atan2</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span> <span class='op'>*</span> <span class='int'>180</span><span class='op'>/</span><span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='op'>::</span><span class='const'>PI</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -4876,7 +4892,7 @@
       <div class="method_details ">
   <h3 class="signature " id="planar_radians-instance_method">
   
-    #<strong>planar_radians</strong>(round: 2)  &#x21d2; <tt>Float</tt> 
+    #<strong>planar_radians</strong>(round: PRECISION)  &#x21d2; <tt>Float</tt> 
   
 
   
@@ -4910,7 +4926,7 @@
         <span class='type'></span>
       
       
-        <em class="default">(defaults to: <tt>2</tt>)</em>
+        <em class="default">(defaults to: <tt>PRECISION</tt>)</em>
       
       
     </li>
@@ -4942,14 +4958,14 @@
       <pre class="lines">
 
 
-325
-326
-327</pre>
+327
+328
+329</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 325</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 327</span>
 
-<span class='kw'>def</span> <span class='id identifier rubyid_planar_radians'>planar_radians</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='int'>2</span><span class='rparen'>)</span>
+<span class='kw'>def</span> <span class='id identifier rubyid_planar_radians'>planar_radians</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_atan2'>atan2</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
 <span class='kw'>end</span></pre>
     </td>
@@ -5033,13 +5049,13 @@
       <pre class="lines">
 
 
-450
-451
 452
-453</pre>
+453
+454
+455</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 450</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 452</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_plus_minus'>plus_minus</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_other_ratio'>other_ratio</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
@@ -5102,13 +5118,13 @@
       <pre class="lines">
 
 
-333
-334
 335
-336</pre>
+336
+337
+338</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 333</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 335</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_prime_divisions'>prime_divisions</span>
   <span class='kw'>return</span> <span class='lbracket'>[</span><span class='lbracket'>[</span><span class='lbracket'>[</span><span class='int'>2</span><span class='comma'>,</span> <span class='int'>1</span><span class='rbracket'>]</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='lbracket'>[</span><span class='lbracket'>[</span><span class='int'>2</span><span class='comma'>,</span> <span class='int'>1</span><span class='rbracket'>]</span><span class='rbracket'>]</span><span class='rbracket'>]</span> <span class='kw'>if</span> <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>==</span> <span class='int'>1</span>
@@ -5175,8 +5191,6 @@
       <pre class="lines">
 
 
-342
-343
 344
 345
 346
@@ -5185,10 +5199,12 @@
 349
 350
 351
-352</pre>
+352
+353
+354</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 342</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 344</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_prime_vector'>prime_vector</span>
   <span class='id identifier rubyid_pds'>pds</span> <span class='op'>=</span> <span class='id identifier rubyid_prime_divisions'>prime_divisions</span>
@@ -5250,12 +5266,12 @@
       <pre class="lines">
 
 
-95
-96
-97</pre>
+97
+98
+99</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 95</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 97</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_ratio'>ratio</span>
   <span class='kw'>self</span>
@@ -5345,13 +5361,13 @@
       <pre class="lines">
 
 
-295
-296
 297
-298</pre>
+298
+299
+300</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 295</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 297</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_scale'>scale</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span> <span class='id identifier rubyid_b'>b</span><span class='op'>=</span><span class='id identifier rubyid_a'>a</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise_if_negative'>raise_if_negative</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span><span class='id identifier rubyid_b'>b</span><span class='rparen'>)</span>
@@ -5442,13 +5458,13 @@
       <pre class="lines">
 
 
-306
-307
 308
-309</pre>
+309
+310
+311</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 306</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 308</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_shear'>shear</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span> <span class='id identifier rubyid_b'>b</span><span class='op'>=</span><span class='id identifier rubyid_a'>a</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise_if_negative'>raise_if_negative</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span><span class='id identifier rubyid_b'>b</span><span class='rparen'>)</span>
@@ -5511,12 +5527,12 @@
       <pre class="lines">
 
 
-174
-175
-176</pre>
+176
+177
+178</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 174</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 176</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_step'>step</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='op'>=</span><span class='int'>12</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Step.html" title="Tonal::Step (class)">Step</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Step.html#initialize-instance_method" title="Tonal::Step#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='comma'>,</span> <span class='label'>modulo:</span> <span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span>
@@ -5582,12 +5598,12 @@
       <pre class="lines">
 
 
-393
-394
-395</pre>
+395
+396
+397</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 393</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 395</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_tenney_height'>tenney_height</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_benedetti_height'>benedetti_height</span><span class='rparen'>)</span>
@@ -5649,12 +5665,12 @@
       <pre class="lines">
 
 
-113
-114
-115</pre>
+115
+116
+117</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 113</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 115</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_a'>to_a</span>
   <span class='lbracket'>[</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rbracket'>]</span>
@@ -5720,12 +5736,12 @@
       <pre class="lines">
 
 
-165
-166
-167</pre>
+167
+168
+169</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 165</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 167</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_cents'>to_cents</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='rparen'>)</span>
@@ -5787,12 +5803,12 @@
       <pre class="lines">
 
 
-138
-139
-140</pre>
+140
+141
+142</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 138</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 140</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_f'>to_f</span>
   <span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span> <span class='op'>/</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span>
@@ -5875,12 +5891,12 @@
       <pre class="lines">
 
 
-147
-148
-149</pre>
+149
+150
+151</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 147</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 149</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_log'>to_log</span><span class='lparen'>(</span><span class='id identifier rubyid_base'>base</span><span class='op'>=</span><span class='int'>2</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log.html" title="Tonal::Log (class)">Log</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='comma'>,</span> <span class='label'>base:</span> <span class='id identifier rubyid_base'>base</span><span class='rparen'>)</span>
@@ -5946,12 +5962,12 @@
       <pre class="lines">
 
 
-156
-157
-158</pre>
+158
+159
+160</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 156</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 158</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_log2'>to_log2</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='rparen'>)</span>
@@ -6013,13 +6029,13 @@
       <pre class="lines">
 
 
-129
-130
 131
-132</pre>
+132
+133
+134</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 129</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 131</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_r'>to_r</span>
   <span class='kw'>return</span> <span class='const'>Float</span><span class='op'>::</span><span class='const'>INFINITY</span> <span class='kw'>if</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='period'>.</span><span class='id identifier rubyid_zero?'>zero?</span> <span class='op'>||</span> <span class='op'>!</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_finite?'>finite?</span>
@@ -6086,12 +6102,12 @@
       <pre class="lines">
 
 
-232
-233
-234</pre>
+234
+235
+236</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 232</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 234</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_reduced_ratio'>to_reduced_ratio</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="ReducedRatio.html" title="Tonal::ReducedRatio (class)">ReducedRatio</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -6153,12 +6169,12 @@
       <pre class="lines">
 
 
-121
-122
-123</pre>
+123
+124
+125</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 121</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 123</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_v'>to_v</span>
   <span class='const'><span class='object_link'><a href="../Vector.html" title="Vector (class)">Vector</a></span></span><span class='lbracket'>[</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rbracket'>]</span>
@@ -6254,13 +6270,13 @@
       <pre class="lines">
 
 
-284
-285
 286
-287</pre>
+287
+288
+289</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 284</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 286</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_translate'>translate</span><span class='lparen'>(</span><span class='id identifier rubyid_x'>x</span><span class='op'>=</span><span class='int'>1</span><span class='comma'>,</span> <span class='id identifier rubyid_y'>y</span><span class='op'>=</span><span class='int'>0</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise_if_negative'>raise_if_negative</span><span class='lparen'>(</span><span class='id identifier rubyid_x'>x</span><span class='comma'>,</span><span class='id identifier rubyid_y'>y</span><span class='rparen'>)</span>
@@ -6323,12 +6339,12 @@
       <pre class="lines">
 
 
-403
-404
-405</pre>
+405
+406
+407</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 403</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 405</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_weil_height'>weil_height</span>
   <span class='lbracket'>[</span><span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_max'>max</span>
@@ -6390,12 +6406,12 @@
       <pre class="lines">
 
 
-420
-421
-422</pre>
+422
+423
+424</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 420</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 422</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_wilson_height'>wilson_height</span><span class='lparen'>(</span><span class='label'>prime_rejects:</span> <span class='lbracket'>[</span><span class='int'>2</span><span class='rbracket'>]</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_benedetti_height'>benedetti_height</span><span class='period'>.</span><span class='id identifier rubyid_prime_division'>prime_division</span><span class='period'>.</span><span class='id identifier rubyid_reject'>reject</span><span class='lbrace'>{</span><span class='op'>|</span><span class='id identifier rubyid_p'>p</span><span class='op'>|</span> <span class='id identifier rubyid_prime_rejects'>prime_rejects</span><span class='period'>.</span><span class='id identifier rubyid_include?'>include?</span><span class='lparen'>(</span><span class='id identifier rubyid_p'>p</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span><span class='rparen'>)</span> <span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_sum'>sum</span><span class='lbrace'>{</span><span class='op'>|</span><span class='id identifier rubyid_p'>p</span><span class='op'>|</span> <span class='id identifier rubyid_p'>p</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span> <span class='op'>*</span> <span class='id identifier rubyid_p'>p</span><span class='period'>.</span><span class='id identifier rubyid_last'>last</span> <span class='rbrace'>}</span>
@@ -6410,7 +6426,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Ratio/Approximation.html
+++ b/docs/Tonal/Ratio/Approximation.html
@@ -1415,7 +1415,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Ratio/Approximation/Set.html
+++ b/docs/Tonal/Ratio/Approximation/Set.html
@@ -488,7 +488,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/ReducedRatio.html
+++ b/docs/Tonal/ReducedRatio.html
@@ -120,6 +120,12 @@
 
 
 
+  
+  
+  <h3 class="inherited">Constants inherited
+     from <span class='object_link'><a href="Ratio.html" title="Tonal::Ratio (class)">Ratio</a></span></h3>
+  <p class="inherited"><span class='object_link'><a href="Ratio.html#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">Tonal::Ratio::PRECISION</a></span></p>
+
 
 
 
@@ -540,7 +546,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Step.html
+++ b/docs/Tonal/Step.html
@@ -1354,7 +1354,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Vector.html
+++ b/docs/Vector.html
@@ -242,7 +242,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:14 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -317,7 +317,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:38 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -83,7 +83,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,7 +83,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -102,7 +102,7 @@
 </div>
 
       <div id="footer">
-  Generated on Thu Dec 19 19:56:39 2024 by
+  Generated on Sun Jan  5 09:38:13 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "6.1.0"
+  TOOLS_VERSION = "6.1.1"
 end

--- a/lib/tonal/irb_helpers.rb
+++ b/lib/tonal/irb_helpers.rb
@@ -12,7 +12,7 @@ module Tonal
 
     # @return [Tonal::ReducedRatio] a reduced ratio
     # @example
-    #   r(3,3) => (1/1)
+    #   rr(3,3) => (1/1)
     # @param arg1 the ratio if only argument provided, or the numerator if two argments are provided
     # @param arg2 the denominator when two arguments are provided
     #

--- a/lib/tonal/log.rb
+++ b/lib/tonal/log.rb
@@ -4,6 +4,8 @@ class Tonal::Log
 
   def_delegators :@logarithmand, :ratio, :to_ratio
 
+  PRECISION = 2
+
   attr_reader :logarithmand, :logarithm, :base
 
   # @return [Tonal::Log]
@@ -72,7 +74,7 @@ class Tonal::Log
   #   Tonal::Log.new(logarithmand: 3/2r, base: 2).inspect => "0.58"
   #
   def inspect
-    "#{logarithm.round(2)}"
+    "#{logarithm.round(PRECISION)}"
   end
 
   def <=>(rhs)

--- a/lib/tonal/ratio.rb
+++ b/lib/tonal/ratio.rb
@@ -4,6 +4,8 @@ class Tonal::Ratio
 
   def_delegators :@approximation, :neighborhood
 
+  PRECISION = 2
+
   attr_reader :antecedent, :consequent, :equave, :reduced_antecedent, :reduced_consequent
 
   # @return [Tonal::Ratio]
@@ -180,7 +182,7 @@ class Tonal::Ratio
   #   Tonal::Ratio.new(3,2).period_degrees => 210.59
   # @param round
   #
-  def period_degrees(round: 2)
+  def period_degrees(round: PRECISION)
     (360.0 * Math.log(to_f, equave)).round(round)
   end
 
@@ -189,7 +191,7 @@ class Tonal::Ratio
   #   Tonal::Ratio.new(3,2).period_radians => 3.68
   # @param round
   #
-  def period_radians(round: 2)
+  def period_radians(round: PRECISION)
     (2 * Math::PI * Math.log(to_f, equave)).round(round)
   end
 
@@ -313,7 +315,7 @@ class Tonal::Ratio
   #    Tonal::Ratio.new(3,2).planar_degrees => 33.69
   # @param round
   #
-  def planar_degrees(round: 2)
+  def planar_degrees(round: PRECISION)
     (Math.atan2(consequent, antecedent) * 180/Math::PI).round(round)
   end
 
@@ -322,7 +324,7 @@ class Tonal::Ratio
   #   Tonal::Ratio.new(3,2).planar_radians => 0.59
   # @param round
   #
-  def planar_radians(round: 2)
+  def planar_radians(round: PRECISION)
     Math.atan2(consequent, antecedent).round(round)
   end
 
@@ -468,7 +470,7 @@ class Tonal::Ratio
     # Return label, if defined; or,
     # Return the "antecedent/consequent", if antecedent is less than 7 digits long; or
     # Return the floating point representation rounded to 2 digits of precision
-    (@label || ((Math.log10(antecedent).to_i + 1) <= 6 ? "#{antecedent}/#{consequent}" : to_f.round(Tonal::Cents::PRECISION))).to_s
+    (@label || ((Math.log10(antecedent).to_i + 1) <= 6 ? "#{antecedent}/#{consequent}" : to_f.round(PRECISION))).to_s
   end
 
   # @return [String] the string representation of Tonal::Ratio


### PR DESCRIPTION
We can control the appearance of precision more easily moving the value for rounding to a constant variable. Each class could have a different precision requirement, so we give each class its own PRECISION variable.

This change adds PRECISION in more classes.

It also fixes an error in documentation.