### PR TITLE
Add Ratio#to_ratio alias

### DIFF
--- a/docs/Array.html
+++ b/docs/Array.html
@@ -1572,7 +1572,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Integer.html
+++ b/docs/Integer.html
@@ -836,7 +836,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Interval.html
+++ b/docs/Interval.html
@@ -164,7 +164,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Math.html
+++ b/docs/Math.html
@@ -230,7 +230,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Numeric.html
+++ b/docs/Numeric.html
@@ -2692,7 +2692,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Prime.html
+++ b/docs/Prime.html
@@ -253,7 +253,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Ratio.html
+++ b/docs/Ratio.html
@@ -144,12 +144,12 @@
       <pre class="lines">
 
 
-627
 628
-629</pre>
+629
+630</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 627</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 628</span>
 
 <span class='kw'>def</span> <span class='kw'>self</span><span class='period'>.</span><span class='op'>[]</span><span class='lparen'>(</span><span class='id identifier rubyid_u'>u</span><span class='comma'>,</span> <span class='id identifier rubyid_l'>l</span><span class='op'>=</span><span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Tonal/Ratio.html" title="Tonal::Ratio (class)">Ratio</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Tonal/Ratio.html#initialize-instance_method" title="Tonal::Ratio#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_u'>u</span><span class='comma'>,</span> <span class='id identifier rubyid_l'>l</span><span class='rparen'>)</span>
@@ -164,7 +164,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/ReducedRatio.html
+++ b/docs/ReducedRatio.html
@@ -164,7 +164,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal.html
+++ b/docs/Tonal.html
@@ -114,7 +114,7 @@
         <dt id="TOOLS_VERSION-constant" class="">TOOLS_VERSION =
           
         </dt>
-        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>6.2.0</span><span class='tstring_end'>&quot;</span></span></pre></dd>
+        <dd><pre class="code"><span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>6.2.1</span><span class='tstring_end'>&quot;</span></span></pre></dd>
       
     </dl>
   
@@ -225,7 +225,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Cents.html
+++ b/docs/Tonal/Cents.html
@@ -1226,7 +1226,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Comma.html
+++ b/docs/Tonal/Comma.html
@@ -498,7 +498,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Hertz.html
+++ b/docs/Tonal/Hertz.html
@@ -822,7 +822,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/IRBHelpers.html
+++ b/docs/Tonal/IRBHelpers.html
@@ -499,7 +499,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Interval.html
+++ b/docs/Tonal/Interval.html
@@ -758,7 +758,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Log.html
+++ b/docs/Tonal/Log.html
@@ -1032,7 +1032,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Log2.html
+++ b/docs/Tonal/Log2.html
@@ -222,7 +222,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Ratio.html
+++ b/docs/Tonal/Ratio.html
@@ -1345,6 +1345,8 @@
     
 
     
+      (also: #to_ratio)
+    
   </span>
   
   
@@ -2022,12 +2024,12 @@
       <pre class="lines">
 
 
-471
 472
-473</pre>
+473
+474</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 471</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 472</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_label'>label</span>
   <span class='ivar'>@label</span>
@@ -2745,12 +2747,12 @@
       <pre class="lines">
 
 
-495
 496
-497</pre>
+497
+498</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 495</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 496</span>
 
 <span class='kw'>def</span> <span class='op'>*</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:*</span><span class='rparen'>)</span>
@@ -2775,12 +2777,12 @@
       <pre class="lines">
 
 
-503
 504
-505</pre>
+505
+506</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 503</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 504</span>
 
 <span class='kw'>def</span> <span class='op'>**</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:**</span><span class='rparen'>)</span>
@@ -2805,12 +2807,12 @@
       <pre class="lines">
 
 
-487
 488
-489</pre>
+489
+490</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 487</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 488</span>
 
 <span class='kw'>def</span> <span class='op'>+</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:+</span><span class='rparen'>)</span>
@@ -2835,12 +2837,12 @@
       <pre class="lines">
 
 
-491
 492
-493</pre>
+493
+494</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 491</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 492</span>
 
 <span class='kw'>def</span> <span class='op'>-</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:-</span><span class='rparen'>)</span>
@@ -2865,12 +2867,12 @@
       <pre class="lines">
 
 
-499
 500
-501</pre>
+501
+502</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 499</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 500</span>
 
 <span class='kw'>def</span> <span class='op'>/</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_operate'>operate</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='comma'>,</span> <span class='symbol'>:/</span><span class='rparen'>)</span>
@@ -2895,14 +2897,14 @@
       <pre class="lines">
 
 
-561
 562
 563
 564
-565</pre>
+565
+566</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 561</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 562</span>
 
 <span class='kw'>def</span> <span class='op'>&lt;=&gt;</span><span class='lparen'>(</span><span class='id identifier rubyid_rhs'>rhs</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_left'>left</span> <span class='op'>=</span> <span class='id identifier rubyid_consequent'>consequent</span> <span class='op'>==</span> <span class='int'>0</span> <span class='op'>?</span> <span class='const'>Float</span><span class='op'>::</span><span class='const'>INFINITY</span> <span class='op'>:</span> <span class='const'>Rational</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rparen'>)</span>
@@ -2958,12 +2960,12 @@
       <pre class="lines">
 
 
-105
 106
-107</pre>
+107
+108</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 105</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 106</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_approximate'>approximate</span>
   <span class='ivar'>@approximation</span>
@@ -3029,12 +3031,12 @@
       <pre class="lines">
 
 
-388
 389
-390</pre>
+390
+391</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 388</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 389</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_benedetti_height'>benedetti_height</span>
   <span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span> <span class='op'>*</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span>
@@ -3116,12 +3118,12 @@
       <pre class="lines">
 
 
-465
 466
-467</pre>
+467
+468</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 465</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 466</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_cent_diff'>cent_diff</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_cents'>cents</span> <span class='op'>-</span> <span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='period'>.</span><span class='id identifier rubyid_ratio'>ratio</span><span class='period'>.</span><span class='id identifier rubyid_cents'>cents</span>
@@ -3187,12 +3189,12 @@
       <pre class="lines">
 
 
-556
 557
-558</pre>
+558
+559</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 556</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 557</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_combination'>combination</span>
   <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>+</span> <span class='id identifier rubyid_consequent'>consequent</span>
@@ -3258,12 +3260,12 @@
       <pre class="lines">
 
 
-547
 548
-549</pre>
+549
+550</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 547</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 548</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_difference'>difference</span>
   <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>-</span> <span class='id identifier rubyid_consequent'>consequent</span>
@@ -3345,13 +3347,13 @@
       <pre class="lines">
 
 
-444
 445
 446
-447</pre>
+447
+448</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 444</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 445</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_div_times'>div_times</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_other_ratio'>other_ratio</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
@@ -3434,14 +3436,14 @@
       <pre class="lines">
 
 
-433
 434
 435
 436
-437</pre>
+437
+438</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 433</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 434</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_efficiency'>efficiency</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span>
   <span class='comment'># We want the efficiency from the ratio (self).
@@ -3531,12 +3533,12 @@
       <pre class="lines">
 
 
-214
 215
-216</pre>
+216
+217</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 214</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 215</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_equave_reduce'>equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='op'>=</span><span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='op'>*</span><span class='id identifier rubyid__equave_reduce'>_equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span><span class='rparen'>)</span>
@@ -3624,13 +3626,13 @@
       <pre class="lines">
 
 
-225
 226
 227
-228</pre>
+228
+229</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 225</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 226</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_equave_reduce!'>equave_reduce!</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='op'>=</span><span class='int'>2</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='ivar'>@antecedent</span><span class='comma'>,</span> <span class='ivar'>@consequent</span> <span class='op'>=</span> <span class='id identifier rubyid__equave_reduce'>_equave_reduce</span><span class='lparen'>(</span><span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -3700,12 +3702,12 @@
       <pre class="lines">
 
 
-205
 206
-207</pre>
+207
+208</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 205</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 206</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_fraction_reduce'>fraction_reduce</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_to_r'>to_r</span><span class='rparen'>)</span>
@@ -3771,12 +3773,12 @@
       <pre class="lines">
 
 
-482
 483
-484</pre>
+484
+485</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 482</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 483</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_inspect'>inspect</span>
   <span class='tstring'><span class='tstring_beg'>&quot;</span><span class='tstring_content'>(</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='embexpr_end'>}</span><span class='tstring_content'>/</span><span class='embexpr_beg'>#{</span><span class='id identifier rubyid_consequent'>consequent</span><span class='embexpr_end'>}</span><span class='tstring_content'>)</span><span class='tstring_end'>&quot;</span></span>
@@ -3867,13 +3869,13 @@
       <pre class="lines">
 
 
-538
 539
 540
-541</pre>
+541
+542</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 538</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 539</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_interval_with'>interval_with</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='op'>=</span><span class='kw'>nil</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_r'>r</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rparen'>)</span>
@@ -3940,12 +3942,12 @@
       <pre class="lines">
 
 
-245
 246
-247</pre>
+247
+248</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 245</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 246</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_invert'>invert</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span>
@@ -4007,13 +4009,13 @@
       <pre class="lines">
 
 
-254
 255
 256
-257</pre>
+257
+258</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 254</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 255</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_invert!'>invert!</span>
   <span class='id identifier rubyid__initialize'>_initialize</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='label'>label:</span> <span class='id identifier rubyid_label'>label</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -4096,12 +4098,12 @@
       <pre class="lines">
 
 
-527
 528
-529</pre>
+529
+530</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 527</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 528</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_lcm'>lcm</span><span class='lparen'>(</span><span class='id identifier rubyid_lhs'>lhs</span><span class='rparen'>)</span>
   <span class='lbracket'>[</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span><span class='comma'>,</span> <span class='id identifier rubyid_lhs'>lhs</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_lcm'>lcm</span>
@@ -4163,12 +4165,12 @@
       <pre class="lines">
 
 
-416
 417
-418</pre>
+418
+419</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 416</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 417</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_log_weil_height'>log_weil_height</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_weil_height'>weil_height</span><span class='rparen'>)</span>
@@ -4230,12 +4232,12 @@
       <pre class="lines">
 
 
-363
 364
-365</pre>
+365
+366</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 363</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 364</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_max_prime'>max_prime</span>
   <span class='id identifier rubyid_prime_divisions'>prime_divisions</span><span class='period'>.</span><span class='id identifier rubyid_flatten'>flatten</span><span class='lparen'>(</span><span class='int'>1</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:first</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_max'>max</span>
@@ -4317,12 +4319,12 @@
       <pre class="lines">
 
 
-380
 381
-382</pre>
+382
+383</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 380</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 381</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_max_prime_within?'>max_prime_within?</span><span class='lparen'>(</span><span class='id identifier rubyid_number'>number</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_max_prime'>max_prime</span> <span class='op'>&lt;=</span> <span class='id identifier rubyid_number'>number</span>
@@ -4403,12 +4405,12 @@
       <pre class="lines">
 
 
-512
 513
-514</pre>
+514
+515</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 512</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 513</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mediant_sum'>mediant_sum</span><span class='lparen'>(</span><span class='id identifier rubyid_number'>number</span><span class='rparen'>)</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>+</span> <span class='id identifier rubyid_number'>number</span><span class='period'>.</span><span class='id identifier rubyid_numerator'>numerator</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span> <span class='op'>+</span> <span class='id identifier rubyid_number'>number</span><span class='period'>.</span><span class='id identifier rubyid_denominator'>denominator</span><span class='rparen'>)</span>
@@ -4470,12 +4472,12 @@
       <pre class="lines">
 
 
-371
 372
-373</pre>
+373
+374</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 371</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 372</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_min_prime'>min_prime</span>
   <span class='id identifier rubyid_prime_divisions'>prime_divisions</span><span class='period'>.</span><span class='id identifier rubyid_flatten'>flatten</span><span class='lparen'>(</span><span class='int'>1</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_map'>map</span><span class='lparen'>(</span><span class='op'>&amp;</span><span class='symbol'>:first</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_min'>min</span>
@@ -4554,12 +4556,12 @@
       <pre class="lines">
 
 
-264
 265
-266</pre>
+266
+267</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 264</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 265</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_mirror'>mirror</span><span class='lparen'>(</span><span class='id identifier rubyid_axis'>axis</span><span class='op'>=</span><span class='int'>1</span><span class='op'>/</span><span class='rational'>1r</span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_axis'>axis</span><span class='rparen'>)</span> <span class='op'>**</span> <span class='int'>2</span><span class='rparen'>)</span> <span class='op'>/</span> <span class='kw'>self</span>
@@ -4621,12 +4623,12 @@
       <pre class="lines">
 
 
-272
 273
-274</pre>
+274
+275</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 272</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 273</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_negative'>negative</span>
   <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='int'>3</span><span class='op'>/</span><span class='rational'>2r</span><span class='rparen'>)</span> <span class='op'>/</span> <span class='kw'>self</span>
@@ -4705,12 +4707,12 @@
       <pre class="lines">
 
 
-187
 188
-189</pre>
+189
+190</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 187</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 188</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_period_degrees'>period_degrees</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='float'>360.0</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log'>log</span><span class='lparen'>(</span><span class='id identifier rubyid_to_f'>to_f</span><span class='comma'>,</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
@@ -4789,12 +4791,12 @@
       <pre class="lines">
 
 
-196
 197
-198</pre>
+198
+199</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 196</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 197</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_period_radians'>period_radians</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='int'>2</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='op'>::</span><span class='const'>PI</span> <span class='op'>*</span> <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_log'>log</span><span class='lparen'>(</span><span class='id identifier rubyid_to_f'>to_f</span><span class='comma'>,</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
@@ -4873,12 +4875,12 @@
       <pre class="lines">
 
 
-320
 321
-322</pre>
+322
+323</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 320</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 321</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_planar_degrees'>planar_degrees</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
   <span class='lparen'>(</span><span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_atan2'>atan2</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span> <span class='op'>*</span> <span class='int'>180</span><span class='op'>/</span><span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='op'>::</span><span class='const'>PI</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
@@ -4957,12 +4959,12 @@
       <pre class="lines">
 
 
-329
 330
-331</pre>
+331
+332</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 329</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 330</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_planar_radians'>planar_radians</span><span class='lparen'>(</span><span class='label'>round:</span> <span class='const'><span class='object_link'><a href="#PRECISION-constant" title="Tonal::Ratio::PRECISION (constant)">PRECISION</a></span></span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Math.html" title="Math (module)">Math</a></span></span><span class='period'>.</span><span class='id identifier rubyid_atan2'>atan2</span><span class='lparen'>(</span><span class='id identifier rubyid_consequent'>consequent</span><span class='comma'>,</span> <span class='id identifier rubyid_antecedent'>antecedent</span><span class='rparen'>)</span><span class='period'>.</span><span class='id identifier rubyid_round'>round</span><span class='lparen'>(</span><span class='id identifier rubyid_round'>round</span><span class='rparen'>)</span>
@@ -5048,13 +5050,13 @@
       <pre class="lines">
 
 
-454
 455
 456
-457</pre>
+457
+458</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 454</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 455</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_plus_minus'>plus_minus</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_other_ratio'>other_ratio</span> <span class='op'>=</span> <span class='kw'>self</span><span class='period'>.</span><span class='id identifier rubyid_class'>class</span><span class='period'>.</span><span class='id identifier rubyid_new'>new</span><span class='lparen'>(</span><span class='id identifier rubyid_other_ratio'>other_ratio</span><span class='rparen'>)</span>
@@ -5117,13 +5119,13 @@
       <pre class="lines">
 
 
-337
 338
 339
-340</pre>
+340
+341</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 337</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 338</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_prime_divisions'>prime_divisions</span>
   <span class='kw'>return</span> <span class='lbracket'>[</span><span class='lbracket'>[</span><span class='lbracket'>[</span><span class='int'>2</span><span class='comma'>,</span> <span class='int'>1</span><span class='rbracket'>]</span><span class='rbracket'>]</span><span class='comma'>,</span> <span class='lbracket'>[</span><span class='lbracket'>[</span><span class='int'>2</span><span class='comma'>,</span> <span class='int'>1</span><span class='rbracket'>]</span><span class='rbracket'>]</span><span class='rbracket'>]</span> <span class='kw'>if</span> <span class='id identifier rubyid_antecedent'>antecedent</span> <span class='op'>==</span> <span class='int'>1</span>
@@ -5190,7 +5192,6 @@
       <pre class="lines">
 
 
-346
 347
 348
 349
@@ -5200,10 +5201,11 @@
 353
 354
 355
-356</pre>
+356
+357</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 346</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 347</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_prime_vector'>prime_vector</span>
   <span class='id identifier rubyid_pds'>pds</span> <span class='op'>=</span> <span class='id identifier rubyid_prime_divisions'>prime_divisions</span>
@@ -5227,6 +5229,10 @@
     #<strong>ratio</strong>  &#x21d2; <tt><span class='object_link'><a href="" title="Tonal::Ratio (class)">Tonal::Ratio</a></span></tt> 
   
 
+  
+    <span class="aliases">Also known as:
+    <span class="names"><span id='to_ratio-instance_method'>to_ratio</span></span>
+    </span>
   
 
   
@@ -5360,13 +5366,13 @@
       <pre class="lines">
 
 
-299
 300
 301
-302</pre>
+302
+303</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 299</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 300</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_scale'>scale</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span> <span class='id identifier rubyid_b'>b</span><span class='op'>=</span><span class='id identifier rubyid_a'>a</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise_if_negative'>raise_if_negative</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span><span class='id identifier rubyid_b'>b</span><span class='rparen'>)</span>
@@ -5457,13 +5463,13 @@
       <pre class="lines">
 
 
-310
 311
 312
-313</pre>
+313
+314</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 310</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 311</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_shear'>shear</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span> <span class='id identifier rubyid_b'>b</span><span class='op'>=</span><span class='id identifier rubyid_a'>a</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise_if_negative'>raise_if_negative</span><span class='lparen'>(</span><span class='id identifier rubyid_a'>a</span><span class='comma'>,</span><span class='id identifier rubyid_b'>b</span><span class='rparen'>)</span>
@@ -5526,12 +5532,12 @@
       <pre class="lines">
 
 
-178
 179
-180</pre>
+180
+181</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 178</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 179</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_step'>step</span><span class='lparen'>(</span><span class='id identifier rubyid_modulo'>modulo</span><span class='op'>=</span><span class='int'>12</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Step.html" title="Tonal::Step (class)">Step</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Step.html#initialize-instance_method" title="Tonal::Step#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='comma'>,</span> <span class='label'>modulo:</span> <span class='id identifier rubyid_modulo'>modulo</span><span class='rparen'>)</span>
@@ -5597,12 +5603,12 @@
       <pre class="lines">
 
 
-397
 398
-399</pre>
+399
+400</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 397</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 398</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_tenney_height'>tenney_height</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_benedetti_height'>benedetti_height</span><span class='rparen'>)</span>
@@ -5664,12 +5670,12 @@
       <pre class="lines">
 
 
-117
 118
-119</pre>
+119
+120</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 117</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 118</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_a'>to_a</span>
   <span class='lbracket'>[</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rbracket'>]</span>
@@ -5735,12 +5741,12 @@
       <pre class="lines">
 
 
-169
 170
-171</pre>
+171
+172</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 169</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 170</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_cents'>to_cents</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Cents.html" title="Tonal::Cents (class)">Cents</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Cents.html#initialize-instance_method" title="Tonal::Cents#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>ratio:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='rparen'>)</span>
@@ -5802,12 +5808,12 @@
       <pre class="lines">
 
 
-142
 143
-144</pre>
+144
+145</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 142</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 143</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_f'>to_f</span>
   <span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span> <span class='op'>/</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='period'>.</span><span class='id identifier rubyid_to_f'>to_f</span>
@@ -5890,12 +5896,12 @@
       <pre class="lines">
 
 
-151
 152
-153</pre>
+153
+154</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 151</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 152</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_log'>to_log</span><span class='lparen'>(</span><span class='id identifier rubyid_base'>base</span><span class='op'>=</span><span class='int'>2</span><span class='rparen'>)</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log.html" title="Tonal::Log (class)">Log</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='comma'>,</span> <span class='label'>base:</span> <span class='id identifier rubyid_base'>base</span><span class='rparen'>)</span>
@@ -5961,12 +5967,12 @@
       <pre class="lines">
 
 
-160
 161
-162</pre>
+162
+163</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 160</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 161</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_log2'>to_log2</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="Log2.html" title="Tonal::Log2 (class)">Log2</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="Log.html#initialize-instance_method" title="Tonal::Log#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='label'>logarithmand:</span> <span class='id identifier rubyid_to_r'>to_r</span><span class='rparen'>)</span>
@@ -6028,13 +6034,13 @@
       <pre class="lines">
 
 
-133
 134
 135
-136</pre>
+136
+137</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 133</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 134</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_r'>to_r</span>
   <span class='kw'>return</span> <span class='const'>Float</span><span class='op'>::</span><span class='const'>INFINITY</span> <span class='kw'>if</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='period'>.</span><span class='id identifier rubyid_zero?'>zero?</span> <span class='op'>||</span> <span class='op'>!</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='period'>.</span><span class='id identifier rubyid_finite?'>finite?</span>
@@ -6101,12 +6107,12 @@
       <pre class="lines">
 
 
-236
 237
-238</pre>
+238
+239</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 236</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 237</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_reduced_ratio'>to_reduced_ratio</span>
   <span class='const'><span class='object_link'><a href="../Tonal.html" title="Tonal (module)">Tonal</a></span></span><span class='op'>::</span><span class='const'><span class='object_link'><a href="ReducedRatio.html" title="Tonal::ReducedRatio (class)">ReducedRatio</a></span></span><span class='period'>.</span><span class='id identifier rubyid_new'><span class='object_link'><a href="ReducedRatio.html#initialize-instance_method" title="Tonal::ReducedRatio#initialize (method)">new</a></span></span><span class='lparen'>(</span><span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span><span class='comma'>,</span> <span class='label'>equave:</span> <span class='id identifier rubyid_equave'>equave</span><span class='rparen'>)</span>
@@ -6168,12 +6174,12 @@
       <pre class="lines">
 
 
-125
 126
-127</pre>
+127
+128</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 125</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 126</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_to_v'>to_v</span>
   <span class='const'><span class='object_link'><a href="../Vector.html" title="Vector (class)">Vector</a></span></span><span class='lbracket'>[</span><span class='id identifier rubyid_antecedent'>antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_consequent'>consequent</span><span class='rbracket'>]</span>
@@ -6269,13 +6275,13 @@
       <pre class="lines">
 
 
-288
 289
 290
-291</pre>
+291
+292</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 288</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 289</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_translate'>translate</span><span class='lparen'>(</span><span class='id identifier rubyid_x'>x</span><span class='op'>=</span><span class='int'>1</span><span class='comma'>,</span> <span class='id identifier rubyid_y'>y</span><span class='op'>=</span><span class='int'>0</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_raise_if_negative'>raise_if_negative</span><span class='lparen'>(</span><span class='id identifier rubyid_x'>x</span><span class='comma'>,</span><span class='id identifier rubyid_y'>y</span><span class='rparen'>)</span>
@@ -6338,12 +6344,12 @@
       <pre class="lines">
 
 
-407
 408
-409</pre>
+409
+410</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 407</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 408</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_weil_height'>weil_height</span>
   <span class='lbracket'>[</span><span class='id identifier rubyid_reduced_antecedent'>reduced_antecedent</span><span class='comma'>,</span> <span class='id identifier rubyid_reduced_consequent'>reduced_consequent</span><span class='rbracket'>]</span><span class='period'>.</span><span class='id identifier rubyid_max'>max</span>
@@ -6405,12 +6411,12 @@
       <pre class="lines">
 
 
-424
 425
-426</pre>
+426
+427</pre>
     </td>
     <td>
-      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 424</span>
+      <pre class="code"><span class="info file"># File 'lib/tonal/ratio.rb', line 425</span>
 
 <span class='kw'>def</span> <span class='id identifier rubyid_wilson_height'>wilson_height</span><span class='lparen'>(</span><span class='label'>prime_rejects:</span> <span class='lbracket'>[</span><span class='int'>2</span><span class='rbracket'>]</span><span class='rparen'>)</span>
   <span class='id identifier rubyid_benedetti_height'>benedetti_height</span><span class='period'>.</span><span class='id identifier rubyid_prime_division'>prime_division</span><span class='period'>.</span><span class='id identifier rubyid_reject'>reject</span><span class='lbrace'>{</span><span class='op'>|</span><span class='id identifier rubyid_p'>p</span><span class='op'>|</span> <span class='id identifier rubyid_prime_rejects'>prime_rejects</span><span class='period'>.</span><span class='id identifier rubyid_include?'>include?</span><span class='lparen'>(</span><span class='id identifier rubyid_p'>p</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span><span class='rparen'>)</span> <span class='rbrace'>}</span><span class='period'>.</span><span class='id identifier rubyid_sum'>sum</span><span class='lbrace'>{</span><span class='op'>|</span><span class='id identifier rubyid_p'>p</span><span class='op'>|</span> <span class='id identifier rubyid_p'>p</span><span class='period'>.</span><span class='id identifier rubyid_first'>first</span> <span class='op'>*</span> <span class='id identifier rubyid_p'>p</span><span class='period'>.</span><span class='id identifier rubyid_last'>last</span> <span class='rbrace'>}</span>
@@ -6425,7 +6431,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Ratio/Approximation.html
+++ b/docs/Tonal/Ratio/Approximation.html
@@ -1415,7 +1415,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Ratio/Approximation/Set.html
+++ b/docs/Tonal/Ratio/Approximation/Set.html
@@ -488,7 +488,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/ReducedRatio.html
+++ b/docs/Tonal/ReducedRatio.html
@@ -546,7 +546,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:27 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Tonal/Step.html
+++ b/docs/Tonal/Step.html
@@ -1354,7 +1354,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/Vector.html
+++ b/docs/Vector.html
@@ -242,7 +242,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/_index.html
+++ b/docs/_index.html
@@ -317,7 +317,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/file.README.html
+++ b/docs/file.README.html
@@ -83,7 +83,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -83,7 +83,7 @@
 </div></div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/docs/top-level-namespace.html
+++ b/docs/top-level-namespace.html
@@ -102,7 +102,7 @@
 </div>
 
       <div id="footer">
-  Generated on Sat Jan 11 22:55:08 2025 by
+  Generated on Thu Jan 16 10:29:26 2025 by
   <a href="https://yardoc.org" title="Yay! A Ruby Documentation Tool" target="_parent">yard</a>
   0.9.37 (ruby-3.3.6).
 </div>

--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "6.2.0"
+  TOOLS_VERSION = "6.2.1"
 end

--- a/lib/tonal/ratio.rb
+++ b/lib/tonal/ratio.rb
@@ -99,6 +99,7 @@ class Tonal::Ratio
   def ratio
     self
   end
+  alias :to_ratio :ratio
 
   # @return [Tonal::Ratio::Approximation] self's approximation instance
   #


### PR DESCRIPTION
Upstream apps can benefit getting a response when calling #to_ratio without having to test the object's class.

This change adds the #to_ratio method to Ratio, so callers can get a response regardless of the object's class.