### PR TITLE
Fix max_prime_within?

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "7.1.0"
+  TOOLS_VERSION = "7.1.1"
 end

--- a/lib/tonal/ratio.rb
+++ b/lib/tonal/ratio.rb
@@ -381,7 +381,7 @@ class Tonal::Ratio
   # @param number to compare max prime against
   #
   def max_prime_within?(number)
-    max_prime <= number
+    max_prime.nil? ? false : max_prime <= number
   end
 
   # @return [Integer] the product complexity of self

--- a/spec/tonal_tools/ratio_spec.rb
+++ b/spec/tonal_tools/ratio_spec.rb
@@ -428,6 +428,12 @@ RSpec.describe Tonal::Ratio do
       it "returns false when the ratio's max prime is greater than the given number" do
         expect(described_class.new(13/8r).max_prime_within?(12)).to be false
       end
+
+      context "when ratio is 1/1" do
+        it "returns false, since 1/1 has no prime, let alone a max prime" do
+          expect(described_class.new(1/1r).max_prime_within?(4)).to be false
+        end
+      end
     end
 
     describe "Comparators" do


### PR DESCRIPTION
The case r(1/1r).max_prime_within?(n) was not be handled.

The r(1/1).max_prime_within?(n) case now returns false, since 1/1 is not prime and will never have a max prime.