### PR TITLE
Add ¢ to output of Tonal::Cents#inspect

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "8.3.4"
+  TOOLS_VERSION = "8.4.0"
 end

--- a/lib/tonal/cents.rb
+++ b/lib/tonal/cents.rb
@@ -91,10 +91,10 @@ class Tonal::Cents
   # @return
   #   [String] the string representation of Tonal::Cents
   # @example
-  #   Tonal::Cents.new(100.0).inspect => "100.0"
+  #   Tonal::Cents.new(100.0).inspect => "100.0 ¢"
   #
   def inspect
-    "#{value.round(@precision)}"
+    "#{value.round(@precision)} ¢"
   end
   alias :to_s :inspect
 

--- a/lib/tonal/extensions.rb
+++ b/lib/tonal/extensions.rb
@@ -142,11 +142,11 @@ class Numeric
   #
   def wilson_height(reduced: false, equave: 2/1r, prime_rejects: [2]) = ratio(reduced:, equave:).wilson_height(prime_rejects:)
 
-  # @return [Float] the cents difference between self and its step in the given modulo
+  # @return [Tonal::Cents] the cents difference between self and its step in the given modulo
   # @example
-  #   (3/2r).efficiency(12) => -1.96
+  #   (3/2r).efficiency(12) => -1.96 ¢
   # @example
-  #   (3/2r).efficiency(12, is_step_efficiency: true) => 1.96
+  #   (3/2r).efficiency(12, is_step_efficiency: true) => 1.96 ¢
   # @param modulo against which the difference of self is compared
   # @param reduced if true, self is reduced to the octave before calculating efficiency
   # @param is_step_efficiency if true, calculates the efficiency of the step instead of the ratio (self). If the step efficiency is X cents, then the ratio efficiency is -X cents.

--- a/lib/tonal/step.rb
+++ b/lib/tonal/step.rb
@@ -78,11 +78,10 @@ class Tonal::Scale
 
     # @return [Tonal::Cents] the difference between the step and the ratio
     # @example
-    #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).efficiency
-    #   => 5.19
+    #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).efficiency => 5.19 ¢
     #
     def efficiency
-      # We want the efficiency from the step (self).
+      # We want the efficiency from the step (self). The step is the tempered approximation of the ratio, so we want to know how far off the step is from the ratio. So we take the ratio and subtract the step.
       ratio_to_cents - step_to_cents
     end
     alias :cents_difference :efficiency


### PR DESCRIPTION
Tonal::Cents looks like another float unless the ¢ symbol is included.

This commit adds the ¢ symbol to the output of Tonal::Cents#inspect.