### PR TITLE
Add Tonal::Step#coprime?

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "8.4.0"
+  TOOLS_VERSION = "8.5.0"
 end

--- a/lib/tonal/step.rb
+++ b/lib/tonal/step.rb
@@ -86,6 +86,15 @@ class Tonal::Scale
     end
     alias :cents_difference :efficiency
 
+    # @return [Boolean] true if the step is coprime to the modulo
+    # @example
+    #   Tonal::Scale::Step.new(step: 5, modulo: 12).coprime? => true
+    #   Tonal::Scale::Step.new(step: 6, modulo: 12).coprime? => false
+    #
+    def coprime?
+      step.coprime?(modulo)
+    end
+
     def +(rhs)
       self.class.new(step: (rhs % modulo), modulo: modulo)
     end

--- a/spec/tonal_tools/step_spec.rb
+++ b/spec/tonal_tools/step_spec.rb
@@ -118,6 +118,26 @@ RSpec.describe Tonal::Scale::Step do
     end
   end
 
+  describe "#coprime?" do
+    context "when step is coprime to modulo" do
+      let(:step) { 5 }
+      let(:modulo) { 12 }
+
+      it "returns true" do
+        expect(subject.coprime?).to be true
+      end
+    end
+
+    context "when step is not coprime to modulo" do
+      let(:step) { 6 }
+      let(:modulo) { 12 }
+
+      it "returns false" do
+        expect(subject.coprime?).to be false
+      end
+    end
+  end
+
   describe "#+" do
     let(:increment) { 41 }
     let(:ratio) { 3/2r }


### PR DESCRIPTION
Knowing the coprimality between the step and modulo is handy.

This commit adds the Step#coprime? method to detemine whether the step and modulo are coprime to each other.