### PR TITLE
Fix Tonal::Scale::Step#step_to_r

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "8.5.0"
+  TOOLS_VERSION = "8.5.1"
 end

--- a/lib/tonal/step.rb
+++ b/lib/tonal/step.rb
@@ -41,10 +41,12 @@ class Tonal::Scale
     # @return [Rational] of the step
     # @example
     #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).step_to_r
-    #   => (6735213777669305/4503599627370496)
+    #   => (18/31)
+    #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 34).step_to_r
+    #   => (10/17)
     #
     def step_to_r
-      tempered.to_r
+      Rational(step, modulo)
     end
     alias :to_r :step_to_r
 

--- a/spec/tonal_tools/step_spec.rb
+++ b/spec/tonal_tools/step_spec.rb
@@ -76,13 +76,19 @@ RSpec.describe Tonal::Scale::Step do
   describe "#step_to_r" do
     let(:ratio) { 3/2r }
 
-    it("returns the rational of the step") { expect(subject.step_to_r).to eq 6735213777669305/4503599627370496r }
+    it("returns the rational of the step") { expect(subject.step_to_r).to eq 18/31r }
+
+    context "when the step and modulo have a common factor" do
+      let(:modulo) { 34 }
+
+      it("returns the rational of the step reduced to lowest terms") { expect(subject.step_to_r).to eq 10/17r }
+    end
   end
 
   describe "#to_r" do
     let(:ratio) { 3/2r }
 
-    it("returns the rational of the step") { expect(subject.to_r).to eq 6735213777669305/4503599627370496r }
+    it("returns the rational of the step") { expect(subject.to_r).to eq 18/31r }
   end
 
   describe "#ratio_to_r" do


### PR DESCRIPTION
The method #step_to_r should fulfill what the name suggests, return a rational based on step/modulo.

This commit changes the #step_to_r method to return step/module.