### PR TITLE
Remove ambiguities

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "8.5.1"
+  TOOLS_VERSION = "8.5.2"
 end

--- a/lib/tonal/step.rb
+++ b/lib/tonal/step.rb
@@ -48,7 +48,6 @@ class Tonal::Scale
     def step_to_r
       Rational(step, modulo)
     end
-    alias :to_r :step_to_r
 
     # @return [Rational] of the ratio
     # @example
@@ -59,15 +58,14 @@ class Tonal::Scale
       ratio.to_r
     end
 
-    # @return [Tonal::Cents] measure of step in cents
+    # @return [Tonal::Cents] measure of tempered in cents
     # @example
-    #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).step_to_cents
+    #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).tempered_to_cents
     #   => 696.77
     #
-    def step_to_cents
+    def tempered_to_cents
       tempered.to_cents
     end
-    alias :to_cents :step_to_cents
 
     # @return [Tonal::Cents] measure of ratio in cents
     # @example
@@ -78,13 +76,13 @@ class Tonal::Scale
       ratio.to_cents
     end
 
-    # @return [Tonal::Cents] the difference between the step and the ratio
+    # @return [Tonal::Cents] the difference between the tempered number and the ratio
     # @example
     #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).efficiency => 5.19 ¢
     #
     def efficiency
-      # We want the efficiency from the step (self). The step is the tempered approximation of the ratio, so we want to know how far off the step is from the ratio. So we take the ratio and subtract the step.
-      ratio_to_cents - step_to_cents
+      # We want the efficiency from the step (self). The tempered value is the tempered approximation of the ratio, so we want to know how far off the step is from the ratio. So we take the ratio and subtract the tempered value.
+      ratio_to_cents - tempered_to_cents
     end
     alias :cents_difference :efficiency
 

--- a/spec/tonal_tools/step_spec.rb
+++ b/spec/tonal_tools/step_spec.rb
@@ -85,34 +85,28 @@ RSpec.describe Tonal::Scale::Step do
     end
   end
 
-  describe "#to_r" do
-    let(:ratio) { 3/2r }
-
-    it("returns the rational of the step") { expect(subject.to_r).to eq 18/31r }
-  end
-
   describe "#ratio_to_r" do
     let(:ratio) { 3/2r }
 
     it("returns the rational of the ratio") { expect(subject.ratio_to_r).to eq 3/2r }
   end
 
-  describe "#step_to_cents" do
+  describe "#tempered_to_cents" do
     let(:ratio) { 3/2r }
 
-    it("returns the cents of the step") { expect(subject.step_to_cents).to eq 696.77 }
-  end
-
-  describe "#to_cents" do
-    let(:ratio) { 3/2r }
-
-    it("returns the cents of the step") { expect(subject.to_cents).to eq 696.77 }
+    it("returns the cents of the tempered") { expect(subject.tempered_to_cents).to eq 696.77 }
   end
 
   describe "#ratio_to_cents" do
     let(:ratio) { 3/2r }
 
     it("returns the cents of the ratio") { expect(subject.ratio_to_cents).to eq 701.96 }
+  end
+
+  describe "#tempered_to_cents" do
+    let(:ratio) { 3/2r }
+
+    it("returns the cents of the tempered") { expect(subject.tempered_to_cents).to eq 696.77 }
   end
 
   describe "#efficiency" do


### PR DESCRIPTION
The method names "to_r" and "to_cents" in Tonal::Scale::Step are too vague. One doesn't know which among the values stored in Step those methods are being applied.

This commit removes the vaguely named methods and requires using the explicitly named methods step_to_r, ratio_to_r and ratio_to_cents instead. This commit also changes the incorrectly named method step_to_cents to tempered_to_cents.