### PR TITLE
Add Tonal::Scale::Step#step_to_ratio

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "8.5.2"
+  TOOLS_VERSION = "8.5.3"
 end

--- a/lib/tonal/step.rb
+++ b/lib/tonal/step.rb
@@ -49,6 +49,15 @@ class Tonal::Scale
       Rational(step, modulo)
     end
 
+    # @return [Tonal::Ratio] of the step/modulo
+    # @example
+    #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).step_to_ratio
+    #   => 18/31
+    #
+    def step_to_ratio
+      Tonal::Ratio.new(step, modulo)
+    end
+
     # @return [Rational] of the ratio
     # @example
     #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).ratio_to_r

--- a/spec/tonal_tools/step_spec.rb
+++ b/spec/tonal_tools/step_spec.rb
@@ -85,6 +85,12 @@ RSpec.describe Tonal::Scale::Step do
     end
   end
 
+  describe "#step_to_ratio" do
+    let(:ratio) { 3/2r }
+    let(:modulo) { 34 }
+    it("returns the ratio of the step/module") { expect(subject.step_to_ratio).to eq Tonal::Ratio.new(20, 34) }
+  end
+
   describe "#ratio_to_r" do
     let(:ratio) { 3/2r }
 


### PR DESCRIPTION
The step/modulo pair can be represented without being reduced with the Tonal::Ratio class.

This method adds the step_to_ratio method.