### PR TITLE
Add MIDI class

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "8.5.3"
+  TOOLS_VERSION = "8.6.0"
 end

--- a/lib/tonal/hertz.rb
+++ b/lib/tonal/hertz.rb
@@ -10,7 +10,7 @@ class Tonal::Hertz
   #
   def initialize(arg)
     raise ArgumentError, "Argument is not Numeric or Tonal::Hertz" unless arg.kind_of?(Numeric) || arg.kind_of?(self.class)
-    @value = arg.kind_of?(self.class) ? arg.inspect : arg
+    @value = arg.kind_of?(self.class) ? arg.value : arg
   end
 
   # @return [Tonal::Hertz] 440 Hz
@@ -45,6 +45,16 @@ class Tonal::Hertz
   def to_cents(reference: self.class.reference)
     Tonal::Cents.new(ratio: to_r / reference.to_r)
   end
+
+  # @return [Tonal::Midi::Note] the midi representation of self
+  # @example
+  #   Tonal::Hertz.new(440).to_midi => 69.0 MIDI
+  # @param reference [Tonal::Hertz, Numeric] the reference frequency to compare to
+  #
+  def to_midi_note
+    Tonal::Midi::Note.new(frequency: to_f)
+  end
+  alias :to_midi :to_midi_note
 
   # @return [String] the string representation of Tonal::Hertz
   # @example

--- a/lib/tonal/midi.rb
+++ b/lib/tonal/midi.rb
@@ -1,0 +1,38 @@
+module Tonal::Midi
+  class Note
+    include Comparable
+
+    REFERENCE_FREQUENCY = 440.0
+    A4_MIDI_NUMBER = 69
+
+    attr_reader :number, :frequency
+
+    # @return [Tonal::Midi::Note]
+    # @example
+    #   Tonal::Midi::Note.new(number:60) => 60.0 MIDI
+    # @param arg [Numeric, Tonal::Midi::Note]
+    #
+    def initialize(number: A4_MIDI_NUMBER, frequency: nil)
+      if frequency
+        raise ArgumentError, "Frequency argument is not Numeric or Tonal::Hertz" unless frequency.kind_of?(Numeric) || frequency.kind_of?(Tonal::Hertz)
+        @frequency = Tonal::Hertz.new(frequency)
+        @number = (A4_MIDI_NUMBER + 12 * Math.log2(frequency.to_f / REFERENCE_FREQUENCY)).round
+      else
+        raise ArgumentError, "Number argument is not Integer" unless number.kind_of?(Integer)
+        @number = number.kind_of?(self.class) ? number.inspect : number
+        @frequency = Tonal::Hertz.new(REFERENCE_FREQUENCY * (2 ** ((number - A4_MIDI_NUMBER) / 12.0)))
+      end
+    end
+
+    alias :value :number
+
+    # @return [String] representation of self
+    def inspect
+      "#{number} MIDI"
+    end
+
+    def <=>(other)
+      number <=> other.number
+    end
+  end
+end

--- a/lib/tonal/tools.rb
+++ b/lib/tonal/tools.rb
@@ -12,6 +12,7 @@ module Tonal
   require "tonal/log"
   require "tonal/log2"
   require "tonal/approximation"
+  require "tonal/midi"
   require "tonal/ratio"
   require "tonal/reduced_ratio"
   require "tonal/extended_ratio"

--- a/spec/tonal_tools/hertz_spec.rb
+++ b/spec/tonal_tools/hertz_spec.rb
@@ -53,6 +53,24 @@ RSpec.describe Tonal::Hertz do
     end
   end
 
+  describe "#to_midi" do
+    let(:frequency) { described_class.new(number) }
+    let(:expected_midi_note) { Tonal::Midi::Note.new(frequency: frequency) }
+
+    it "returns the midi difference from the default reference frequency, 440 Hz" do
+      expect(frequency.to_midi).to eq expected_midi_note
+    end
+# (number: A4_MIDI_NUMBER, frequency: nil)
+    context "with a custom reference frequency" do
+      let(:frequency) { described_class.new(200) }
+      let(:expected_midi_note) { Tonal::Midi::Note.new(frequency: frequency) }
+
+      it "returns the midi difference from the custom reference frequency" do
+        expect(frequency.to_midi).to eq expected_midi_note
+      end
+    end
+  end
+
   describe "#value" do
     it "returns the value that was input" do
       expect(described_class.new(number).value).to eq 400

--- a/spec/tonal_tools/midi_spec.rb
+++ b/spec/tonal_tools/midi_spec.rb
@@ -1,0 +1,55 @@
+RSpec.describe Tonal::Midi::Note do
+  let(:number) { 60 }
+
+  describe "initialization" do
+    context "without an argument" do
+      it "creates a new Tonal::Midi::Note instance with the default value" do
+        midi = described_class.new
+        expect(midi.number).to eq described_class::A4_MIDI_NUMBER
+      end
+    end
+
+    context "with a number argument" do
+      it "creates a new Tonal::Midi::Note instance with the given value" do
+        midi = described_class.new(number: number)
+        expect(midi.number).to eq number
+      end
+    end
+
+    context "with an invalid argument" do
+      it "raises an ArgumentError" do
+        expect { described_class.new(number: "invalid") }.to raise_error(ArgumentError, "Number argument is not Integer")
+      end
+    end
+
+    context "initialization with frequency" do
+      let(:frequency) { 440.0 }
+
+      it "creates a new Tonal::Midi::Note instance with the given frequency" do
+        midi = described_class.new(frequency: frequency)
+        expect(midi.frequency.to_f).to eq frequency
+        expect(midi.number).to eq 69
+      end
+
+      context "with an invalid frequency argument" do
+        it "raises an ArgumentError" do
+          expect { described_class.new(frequency: "invalid") }.to raise_error(ArgumentError, "Frequency argument is not Numeric or Tonal::Hertz")
+        end
+      end
+    end
+  end
+
+  describe "#inspect" do
+    it "returns a string representation of the MIDI note" do
+      midi = described_class.new(number: number)
+      expect(midi.inspect).to eq "#{number} MIDI"
+    end
+  end
+
+  describe "#frequency" do
+    it "returns the frequency corresponding to the MIDI note number" do
+      midi = described_class.new(number: number)
+      expect(midi.frequency.to_f).to eq 261.6255653005986
+    end
+  end
+end


### PR DESCRIPTION
We want to calculate MIDI numbers given frequency (Hertz) measurements.

This commit adds the Tonal::Midi::Note class. It's used by Tonal::Hertz to return the MIDI number associated with it.

This commit also fixes a bug in the Tonal::Hertz intializer.