### PR TITLE
Add Tonal::Scale::Step#step_to_midi

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "8.6.0"
+  TOOLS_VERSION = "8.7.0"
 end

--- a/lib/tonal/midi.rb
+++ b/lib/tonal/midi.rb
@@ -4,6 +4,7 @@ module Tonal::Midi
 
     REFERENCE_FREQUENCY = 440.0
     A4_MIDI_NUMBER = 69
+    C4_MIDI_NUMBER = 60
 
     attr_reader :number, :frequency
 
@@ -32,7 +33,7 @@ module Tonal::Midi
     end
 
     def <=>(other)
-      number <=> other.number
+      number <=> (other.kind_of?(self.class) ? other.number : other)
     end
   end
 end

--- a/lib/tonal/step.rb
+++ b/lib/tonal/step.rb
@@ -58,6 +58,22 @@ class Tonal::Scale
       Tonal::Ratio.new(step, modulo)
     end
 
+    # @return the [Tonal::Midi::Note] representation of the step
+    #
+    # @example
+    #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).step_to_midi
+    #   => 78
+    #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 12).step_to_midi
+    #   => 67
+    #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 12).step_to_midi(midi_root: Tonal::Midi::Note::A4_MIDI_NUMBER)
+    #   => 76
+    #
+    # @param midi_root [Integer] the MIDI number that corresponds to the 0 step of the scale. Default is C4 (60 MIDI).
+    #
+    def step_to_midi(midi_root: Tonal::Midi::Note::C4_MIDI_NUMBER)
+      Tonal::Midi::Note.new(number: step + midi_root)
+    end
+
     # @return the [Rational] representation of the ratio of self
     # @example
     #   Tonal::Scale::Step.new(ratio: 3/2r, modulo: 31).ratio_to_r

--- a/spec/tonal_tools/step_spec.rb
+++ b/spec/tonal_tools/step_spec.rb
@@ -91,6 +91,12 @@ RSpec.describe Tonal::Scale::Step do
     it("returns the ratio of the step/module") { expect(subject.step_to_ratio).to eq Tonal::Ratio.new(20, 34) }
   end
 
+  describe "#step_to_midi" do
+    let(:ratio) { 3/2r }
+
+    it("returns the MIDI number of the step") { expect(subject.step_to_midi).to eq 78 }
+  end
+
   describe "#ratio_to_r" do
     let(:ratio) { 3/2r }
 


### PR DESCRIPTION
Mapping scale steps to MIDI notes comes in handy when working with synths.

This commit adds the #step_to_midi method. By default the C4 MIDI value is used as the root.