### PR TITLE
Add #to_hertz and #to_midi

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "8.7.0"
+  TOOLS_VERSION = "8.8.0"
 end

--- a/lib/tonal/hertz.rb
+++ b/lib/tonal/hertz.rb
@@ -1,6 +1,8 @@
 class Tonal::Hertz
   include Comparable
 
+  REFERENCE_FREQUENCY = 440.0
+
   attr_reader :value
 
   # @return [Tonal::Hertz]
@@ -18,7 +20,7 @@ class Tonal::Hertz
   #   Tonal::Hertz.reference => 440.0 Hz
   #
   def self.reference
-    self.new(440.0)
+    self.new(REFERENCE_FREQUENCY)
   end
 
   # @return [Rational] self as a rational
@@ -50,9 +52,10 @@ class Tonal::Hertz
   # @example
   #   Tonal::Hertz.new(440).to_midi => 69.0 MIDI
   # @param reference [Tonal::Hertz, Numeric] the reference frequency to compare to
+  # @param modulo [Integer] the modulo to use for the MIDI note calculation
   #
-  def to_midi_note
-    Tonal::Midi::Note.new(frequency: to_f)
+  def to_midi_note(modulo: Tonal::Midi::Note::DEFAULT_MODULO)
+    Tonal::Midi::Note.new(frequency: to_f, modulo: modulo)
   end
   alias :to_midi :to_midi_note
 

--- a/lib/tonal/midi.rb
+++ b/lib/tonal/midi.rb
@@ -2,30 +2,46 @@ module Tonal::Midi
   class Note
     include Comparable
 
-    REFERENCE_FREQUENCY = 440.0
     A4_MIDI_NUMBER = 69
     C4_MIDI_NUMBER = 60
+    DEFAULT_MODULO = 12
 
-    attr_reader :number, :frequency
+    attr_reader :number, :modulo
 
     # @return [Tonal::Midi::Note]
     # @example
-    #   Tonal::Midi::Note.new(number:60) => 60.0 MIDI
-    # @param arg [Numeric, Tonal::Midi::Note]
+    #   Tonal::Midi::Note.new(number: 60) => 60 MIDI
+    #   Tonal::Midi::Note.new(frequency: 261.63) => 60 MIDI
+    # @param number [Integer, nil] the MIDI note number. Mutually exclusive with frequency:
+    # @param frequency [Numeric, Tonal::Hertz, nil] the frequency in Hz. Mutually exclusive with number:
+    # @param modulo [Integer] the number of steps per octave
     #
-    def initialize(number: A4_MIDI_NUMBER, frequency: nil)
+    def initialize(number: nil, frequency: nil, modulo: DEFAULT_MODULO)
+      raise ArgumentError, "Provide either number: or frequency:, not both" if number && frequency
+
+      @modulo = modulo
       if frequency
         raise ArgumentError, "Frequency argument is not Numeric or Tonal::Hertz" unless frequency.kind_of?(Numeric) || frequency.kind_of?(Tonal::Hertz)
         @frequency = Tonal::Hertz.new(frequency)
-        @number = (A4_MIDI_NUMBER + 12 * Math.log2(frequency.to_f / REFERENCE_FREQUENCY)).round
+        @number = (A4_MIDI_NUMBER + modulo * Math.log2(frequency.to_f / Tonal::Hertz::REFERENCE_FREQUENCY)).round
       else
+        number = A4_MIDI_NUMBER if number.nil?
         raise ArgumentError, "Number argument is not Integer" unless number.kind_of?(Integer)
-        @number = number.kind_of?(self.class) ? number.inspect : number
-        @frequency = Tonal::Hertz.new(REFERENCE_FREQUENCY * (2 ** ((number - A4_MIDI_NUMBER) / 12.0)))
+        @number = number
+        @frequency = Tonal::Hertz.new(Tonal::Hertz::REFERENCE_FREQUENCY * (2 ** ((number - A4_MIDI_NUMBER) / modulo.to_f)))
       end
     end
 
     alias :value :number
+
+    # @return [Float] the frequency corresponding to the MIDI note number
+    # @example
+    #   Tonal::Midi::Note.new(number:60).frequency => 261.6255653005986
+    # @param round [Integer, nil] the number of decimal places to round the frequency to, or nil for no rounding
+    #
+    def frequency(round: nil)
+      round ? @frequency.to_f.round(round) : @frequency.to_f
+    end
 
     # @return [String] representation of self
     def inspect

--- a/lib/tonal/ratio.rb
+++ b/lib/tonal/ratio.rb
@@ -174,6 +174,25 @@ class Tonal::Ratio
   end
   alias :cents :to_cents
 
+  # @return [Tonal::Hertz] the hertz of self with respect to a reference frequency
+  # @example
+  #   Tonal::Ratio.new(3,2).to_hertz => 660.0
+  # @param reference [Numeric] the reference frequency
+  #
+  def to_hertz(reference: Tonal::Hertz.reference)
+    Tonal::Hertz.new(reference.to_f * to_f)
+  end
+
+  # @return [Tonal::Midi::Note] the midi representation of self with respect to a reference frequency
+  # @example
+  #   Tonal::Ratio.new(3,2).to_midi => 76 MIDI
+  # @param reference [Numeric] the reference frequency
+  # @param modulo [Integer] the modulo for the MIDI note
+  #
+  def to_midi(reference: Tonal::Hertz.reference, modulo: Tonal::Midi::Note::DEFAULT_MODULO)
+    to_hertz(reference: reference).to_midi(modulo: modulo)
+  end
+
   # @return [Integer] the step of self in the given modulo
   # @example
   #   Tonal::ReducedRatio.new(3,2).step(12) => 7\12

--- a/spec/tonal_tools/midi_spec.rb
+++ b/spec/tonal_tools/midi_spec.rb
@@ -3,16 +3,16 @@ RSpec.describe Tonal::Midi::Note do
 
   describe "initialization" do
     context "without an argument" do
-      it "creates a new Tonal::Midi::Note instance with the default value" do
-        midi = described_class.new
-        expect(midi.number).to eq described_class::A4_MIDI_NUMBER
+      it "creates a Tonal::Midi::Note instance with the default MIDI number of 69 and a frequency of 440.0 Hz" do
+        expect(described_class.new.number).to eq described_class::A4_MIDI_NUMBER
+        expect(described_class.new.frequency).to eq 440.0
       end
     end
 
     context "with a number argument" do
-      it "creates a new Tonal::Midi::Note instance with the given value" do
-        midi = described_class.new(number: number)
-        expect(midi.number).to eq number
+      it "creates a Tonal::Midi::Note instance assigned the given number and calculates the corresponding frequency" do
+        expect(described_class.new(number: number).number).to eq number
+        expect(described_class.new(number: number).frequency(round: 2)).to eq 261.63
       end
     end
 
@@ -22,19 +22,50 @@ RSpec.describe Tonal::Midi::Note do
       end
     end
 
-    context "initialization with frequency" do
-      let(:frequency) { 440.0 }
+    context "with frequency" do
+      let(:frequency) { 220.0 }
 
-      it "creates a new Tonal::Midi::Note instance with the given frequency" do
+      it "creates a Tonal::Midi::Note instance with the given frequency and MIDI number relative to A4_MIDI_NUMBER" do
         midi = described_class.new(frequency: frequency)
-        expect(midi.frequency.to_f).to eq frequency
-        expect(midi.number).to eq 69
+        expect(midi.frequency).to eq frequency
+        expect(midi.number).to eq 57
       end
 
       context "with an invalid frequency argument" do
         it "raises an ArgumentError" do
           expect { described_class.new(frequency: "invalid") }.to raise_error(ArgumentError, "Frequency argument is not Numeric or Tonal::Hertz")
         end
+      end
+    end
+
+    context "with both number and frequency" do
+      it "raises an ArgumentError" do
+        expect { described_class.new(number: number, frequency: 440.0) }
+          .to raise_error(ArgumentError, "Provide either number: or frequency:, not both")
+      end
+    end
+
+    context "with modulo" do
+      let(:modulo) { 24 }
+
+      it "creates a Tonal::Midi::Note instance with the given modulo and calculates the corresponding frequency" do
+        midi = described_class.new(number: number, modulo: modulo)
+        expect(midi.modulo).to eq modulo
+        expect(midi.frequency(round: 2)).to eq 339.29
+      end
+    end
+  end
+
+  describe "#frequency" do
+    let(:midi) { described_class.new(number: number) }
+
+    it "returns the frequency corresponding to the MIDI note number" do
+      expect(midi.frequency).to eq 261.6255653005986
+    end
+
+    context "with rounding" do
+      it "returns the frequency rounded to the specified number of decimal places" do
+        expect(midi.frequency(round: 2)).to eq 261.63
       end
     end
   end

--- a/spec/tonal_tools/ratio_spec.rb
+++ b/spec/tonal_tools/ratio_spec.rb
@@ -198,6 +198,46 @@ RSpec.describe Tonal::Ratio do
       end
     end
 
+    describe "#to_hertz" do
+      it "returns the reference frequency for the 1/1 ratio by default" do
+        expect(described_class.new(1/1r).to_hertz.to_f).to eq 440.0
+      end
+
+      it "returns the hertz of self" do
+        expect(subject.to_hertz).to be_a_kind_of(Tonal::Hertz)
+        expect(subject.to_hertz.to_f).to eq 660.0
+      end
+
+      context "with a custom reference frequency" do
+        let(:reference) { 220.0 }
+
+        it "returns the hertz of self with respect to the custom reference frequency" do
+          expect(subject.to_hertz(reference: reference)).to be_a_kind_of(Tonal::Hertz)
+          expect(subject.to_hertz(reference: reference).to_f).to eq 330.0
+        end
+      end
+    end
+
+    describe "#to_midi" do
+      it "returns the MIDI note of A440 for the 1/1 ratio by default" do
+        expect(described_class.new(1/1r).to_midi.number).to eq 69
+      end
+
+      it "returns the midi of self" do
+        expect(subject.to_midi).to be_a_kind_of(Tonal::Midi::Note)
+        expect(subject.to_midi.number).to eq 76
+      end
+
+      context "with a custom reference frequency" do
+        let(:reference) { 220.0 }
+
+        it "returns the midi of self with respect to the custom reference frequency" do
+          expect(subject.to_midi(reference: reference)).to be_a_kind_of(Tonal::Midi::Note)
+          expect(subject.to_midi(reference: reference).number).to eq 64
+        end
+      end
+    end
+
     describe "#step" do
       it "returns the step of self in a given modulo" do
         expect(subject.step).to eq Tonal::Scale::Step.new(modulo: 12, ratio: 3/2r)


### PR DESCRIPTION
It's useful having conversions from Ratio to Hertz and Midi.

This change adds Tonal::Ratio#to_hertz and #to_midi, as well as adding Tonal::Hertz#to_midi_note.