### PR TITLE
Fix Tonal::Ratio#to_midi

### DIFF
--- a/lib/tonal/attributions.rb
+++ b/lib/tonal/attributions.rb
@@ -1,4 +1,4 @@
 module Tonal
   TOOLS_PRODUCER = "mTonal"
-  TOOLS_VERSION = "8.8.0"
+  TOOLS_VERSION = "8.8.1"
 end

--- a/lib/tonal/hertz.rb
+++ b/lib/tonal/hertz.rb
@@ -51,11 +51,12 @@ class Tonal::Hertz
   # @return [Tonal::Midi::Note] the midi representation of self
   # @example
   #   Tonal::Hertz.new(440).to_midi => 69.0 MIDI
-  # @param reference [Tonal::Hertz, Numeric] the reference frequency to compare to
   # @param modulo [Integer] the modulo to use for the MIDI note calculation
+  # @param reference_number [Integer] the MIDI note number that anchors the conversion
+  # @param reference_frequency [Numeric] the frequency (Hz) that anchors the conversion
   #
-  def to_midi_note(modulo: Tonal::Midi::Note::DEFAULT_MODULO)
-    Tonal::Midi::Note.new(frequency: to_f, modulo: modulo)
+  def to_midi_note(modulo: Tonal::Midi::Note::DEFAULT_MODULO, reference_number: Tonal::Midi::Note::A4_MIDI_NUMBER, reference_frequency: Tonal::Hertz::REFERENCE_FREQUENCY)
+    Tonal::Midi::Note.new(frequency: to_f, modulo: modulo, reference_number: reference_number, reference_frequency: reference_frequency)
   end
   alias :to_midi :to_midi_note
 

--- a/lib/tonal/midi.rb
+++ b/lib/tonal/midi.rb
@@ -6,7 +6,7 @@ module Tonal::Midi
     C4_MIDI_NUMBER = 60
     DEFAULT_MODULO = 12
 
-    attr_reader :number, :modulo
+    attr_reader :number, :modulo, :reference_number, :reference_frequency
 
     # @return [Tonal::Midi::Note]
     # @example
@@ -15,20 +15,24 @@ module Tonal::Midi
     # @param number [Integer, nil] the MIDI note number. Mutually exclusive with frequency:
     # @param frequency [Numeric, Tonal::Hertz, nil] the frequency in Hz. Mutually exclusive with number:
     # @param modulo [Integer] the number of steps per octave
+    # @param reference_number [Integer] the MIDI note number that anchors the number/frequency conversion
+    # @param reference_frequency [Numeric] the frequency (Hz) that anchors the number/frequency conversion
     #
-    def initialize(number: nil, frequency: nil, modulo: DEFAULT_MODULO)
+    def initialize(number: nil, frequency: nil, modulo: DEFAULT_MODULO, reference_number: A4_MIDI_NUMBER, reference_frequency: Tonal::Hertz::REFERENCE_FREQUENCY)
       raise ArgumentError, "Provide either number: or frequency:, not both" if number && frequency
 
       @modulo = modulo
+      @reference_number = reference_number
+      @reference_frequency = reference_frequency.to_f
       if frequency
         raise ArgumentError, "Frequency argument is not Numeric or Tonal::Hertz" unless frequency.kind_of?(Numeric) || frequency.kind_of?(Tonal::Hertz)
         @frequency = Tonal::Hertz.new(frequency)
-        @number = (A4_MIDI_NUMBER + modulo * Math.log2(frequency.to_f / Tonal::Hertz::REFERENCE_FREQUENCY)).round
+        @number = (@reference_number + modulo * Math.log2(frequency.to_f / @reference_frequency)).round
       else
-        number = A4_MIDI_NUMBER if number.nil?
+        number = @reference_number if number.nil?
         raise ArgumentError, "Number argument is not Integer" unless number.kind_of?(Integer)
         @number = number
-        @frequency = Tonal::Hertz.new(Tonal::Hertz::REFERENCE_FREQUENCY * (2 ** ((number - A4_MIDI_NUMBER) / modulo.to_f)))
+        @frequency = Tonal::Hertz.new(@reference_frequency * (2 ** ((number - @reference_number) / modulo.to_f)))
       end
     end
 

--- a/lib/tonal/ratio.rb
+++ b/lib/tonal/ratio.rb
@@ -187,10 +187,13 @@ class Tonal::Ratio
   # @example
   #   Tonal::Ratio.new(3,2).to_midi => 76 MIDI
   # @param reference [Numeric] the reference frequency
-  # @param modulo [Integer] the modulo for the MIDI note
+  # @param modulo [Integer] the number of steps per octave used to scale self's offset from reference. The
+  #   reference frequency's own MIDI note number is always computed independently of modulo.
   #
   def to_midi(reference: Tonal::Hertz.reference, modulo: Tonal::Midi::Note::DEFAULT_MODULO)
-    to_hertz(reference: reference).to_midi(modulo: modulo)
+    reference_hertz = Tonal::Hertz.new(reference)
+    reference_number = reference_hertz.to_midi_note.number
+    to_hertz(reference: reference_hertz).to_midi_note(modulo: modulo, reference_number: reference_number, reference_frequency: reference_hertz.to_f)
   end
 
   # @return [Integer] the step of self in the given modulo

--- a/spec/tonal_tools/hertz_spec.rb
+++ b/spec/tonal_tools/hertz_spec.rb
@@ -69,6 +69,16 @@ RSpec.describe Tonal::Hertz do
         expect(frequency.to_midi).to eq expected_midi_note
       end
     end
+
+    context "with a custom reference_number and reference_frequency" do
+      let(:frequency) { described_class.new(523.26) }
+
+      it "anchors the conversion on the given reference_number/reference_frequency instead of A4/440" do
+        midi = frequency.to_midi(modulo: 31, reference_number: 60, reference_frequency: 261.63)
+        expect(midi.number).to eq 91
+        expect(midi.frequency).to eq 523.26
+      end
+    end
   end
 
   describe "#value" do

--- a/spec/tonal_tools/midi_spec.rb
+++ b/spec/tonal_tools/midi_spec.rb
@@ -54,6 +54,21 @@ RSpec.describe Tonal::Midi::Note do
         expect(midi.frequency(round: 2)).to eq 339.29
       end
     end
+
+    context "with a custom reference_number and reference_frequency" do
+      it "anchors the number/frequency conversion on the given reference instead of A4/440" do
+        midi = described_class.new(frequency: 523.26, modulo: 31, reference_number: 60, reference_frequency: 261.63)
+        expect(midi.reference_number).to eq 60
+        expect(midi.reference_frequency).to eq 261.63
+        expect(midi.number).to eq 91
+      end
+
+      it "defaults to A4_MIDI_NUMBER and REFERENCE_FREQUENCY" do
+        midi = described_class.new(number: number)
+        expect(midi.reference_number).to eq described_class::A4_MIDI_NUMBER
+        expect(midi.reference_frequency).to eq Tonal::Hertz::REFERENCE_FREQUENCY
+      end
+    end
   end
 
   describe "#frequency" do

--- a/spec/tonal_tools/ratio_spec.rb
+++ b/spec/tonal_tools/ratio_spec.rb
@@ -236,6 +236,22 @@ RSpec.describe Tonal::Ratio do
           expect(subject.to_midi(reference: reference).number).to eq 64
         end
       end
+
+      context "with a custom modulo" do
+        let(:reference) { 261.63 }
+
+        it "scales self's offset from the reference by modulo, without shifting the reference note itself" do
+          expect(described_class.new(1/1r).to_midi(reference: reference).number).to eq 60
+          expect(described_class.new(2/1r).to_midi(reference: reference).number).to eq 72
+          expect(described_class.new(1/1r).to_midi(reference: reference, modulo: 31).number).to eq 60
+          expect(described_class.new(2/1r).to_midi(reference: reference, modulo: 31).number).to eq 91
+        end
+
+        it "keeps the resulting frequency exact" do
+          note = described_class.new(2/1r).to_midi(reference: reference, modulo: 31)
+          expect(note.frequency).to eq 523.26
+        end
+      end
     end
 
     describe "#step" do


### PR DESCRIPTION
The Tonal::Ratio#to_midi wasn't calculating MIDI notes scaled to the provided custom modulo correctly.

This change fixes the bug. Now, custom modulos produces the correct MIDI notes:

```
Tonal::Ratio.new(1/1r).to_midi(reference: 261.63) => 60 MIDI
Tonal::Ratio.new(2/1r).to_midi(reference: 261.63) => 72 MIDI

Tonal::Ratio.new(1/1r).to_midi(reference: 261.63, modulo: 31) => 60 MIDI
Tonal::Ratio.new(2/1r).to_midi(reference: 261.63, modulo: 31) => 91 MIDI
```